### PR TITLE
Lint fix

### DIFF
--- a/alohomora_lints/src/alohomora_sandbox.rs
+++ b/alohomora_lints/src/alohomora_sandbox.rs
@@ -67,9 +67,14 @@ fn check_crate(cx: &LateContext<'_>) {
     }
 
     let nested_trait_impls = cx.tcx.trait_impls_of(def_id.unwrap());
-    let trait_impls = nested_trait_impls.non_blanket_impls().iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
-    trait_impls.iter().filter(|def_id| !contains_secret(cx, def_id)).for_each(|def_id| {
-        error_message(cx, def_id);
+    let trait_impls = nested_trait_impls.non_blanket_impls()
+        .iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
+    trait_impls.iter()
+        .filter(|def_id| 
+            !contains_secret(cx, def_id) 
+            && def_id.krate == rustc_hir::def_id::LOCAL_CRATE)
+        .for_each(|def_id| {
+            error_message(cx, def_id);
     });
 }
 

--- a/alohomora_lints/src/alohomora_sandbox_identity_transfer.rs
+++ b/alohomora_lints/src/alohomora_sandbox_identity_transfer.rs
@@ -67,8 +67,14 @@ fn check_crate(cx: &LateContext<'_>) {
     }
 
     let nested_trait_impls = cx.tcx.trait_impls_of(def_id.unwrap());
-    let trait_impls = nested_trait_impls.non_blanket_impls().iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
-    trait_impls.iter().filter(|def_id| !contains_secret(cx, def_id)).for_each(|def_id| {
-        error_message(cx, def_id);
-    });
+    let trait_impls = nested_trait_impls.non_blanket_impls()
+        .iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
+    
+    trait_impls.iter()
+        .filter(|def_id| 
+            !contains_secret(cx, def_id) 
+            && def_id.krate == rustc_hir::def_id::LOCAL_CRATE)
+        .for_each(|def_id| {
+            error_message(cx, def_id);
+        });
 }

--- a/alohomora_lints/src/alohomora_sandbox_transfer.rs
+++ b/alohomora_lints/src/alohomora_sandbox_transfer.rs
@@ -67,9 +67,15 @@ fn check_crate(cx: &LateContext<'_>) {
     }
 
     let nested_trait_impls = cx.tcx.trait_impls_of(def_id.unwrap());
-    let trait_impls = nested_trait_impls.non_blanket_impls().iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
-    trait_impls.iter().filter(|def_id| !contains_secret(cx, def_id)).for_each(|def_id| {
-        error_message(cx, def_id);
+    let trait_impls = nested_trait_impls.non_blanket_impls()
+        .iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
+    
+    trait_impls.iter()
+        .filter(|def_id| 
+            !contains_secret(cx, def_id) 
+            && def_id.krate == rustc_hir::def_id::LOCAL_CRATE)
+        .for_each(|def_id| {
+            error_message(cx, def_id);
     });
 }
 

--- a/alohomora_lints/src/alohomora_type.rs
+++ b/alohomora_lints/src/alohomora_type.rs
@@ -68,8 +68,8 @@ fn check_crate(cx: &LateContext<'_>) {
     }
 
     let nested_trait_impls = cx.tcx.trait_impls_of(aloh_ty_def_id.unwrap());
-    let trait_impls = nested_trait_impls.non_blanket_impls().iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
-    trait_impls.iter().filter(|def_id| !contains_secret(cx, def_id)).for_each(|def_id| {
+    let trait_impls: Vec<DefId> = nested_trait_impls.non_blanket_impls().iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
+    trait_impls.iter().filter(|def_id| !contains_secret(cx, def_id) && def_id.krate == rustc_hir::def_id::LOCAL_CRATE).for_each(|def_id| {
         error_message(cx, def_id);
     });
 }

--- a/alohomora_lints/src/alohomora_type.rs
+++ b/alohomora_lints/src/alohomora_type.rs
@@ -68,9 +68,15 @@ fn check_crate(cx: &LateContext<'_>) {
     }
 
     let nested_trait_impls = cx.tcx.trait_impls_of(aloh_ty_def_id.unwrap());
-    let trait_impls: Vec<DefId> = nested_trait_impls.non_blanket_impls().iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
-    trait_impls.iter().filter(|def_id| !contains_secret(cx, def_id) && def_id.krate == rustc_hir::def_id::LOCAL_CRATE).for_each(|def_id| {
-        error_message(cx, def_id);
+    let trait_impls: Vec<DefId> = nested_trait_impls.non_blanket_impls()
+        .iter().fold(Vec::new(), |mut acc, (_, v)| { acc.extend(v.iter()); acc });
+    
+    trait_impls.iter()
+        .filter(|def_id| 
+            !contains_secret(cx, def_id) 
+            && def_id.krate == rustc_hir::def_id::LOCAL_CRATE)
+        .for_each(|def_id| {
+            error_message(cx, def_id);
     });
 }
 

--- a/alohomora_lints/src/lib.rs
+++ b/alohomora_lints/src/lib.rs
@@ -4,6 +4,7 @@ extern crate rustc_lint;
 extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate rustc_hir; 
 
 // Helper for declaring lints without too much boilerplate.
 macro_rules! declare_alohomora_lint {


### PR DESCRIPTION
The trait implementation lints now only check the local crate. 
Fixed a bug caused by the attributes of an `impl` block not being visible in a non-local crate, such that the Sesame secret docstring in the lib crate wasn't visible while linting the bin crate, and vice versa. 