### PR TITLE
Updates related to changes in Scrutinizer and plotting scripts

### DIFF
--- a/alohomora/src/orm/mod.rs
+++ b/alohomora/src/orm/mod.rs
@@ -4,7 +4,7 @@ mod value;
 mod policy;
 
 pub use database::*;
-pub use rocket::*;
+pub use self::rocket::*;
 pub use value::*;
 pub use policy::*;
 

--- a/alohomora_build/src/scrutinizer/mod.rs
+++ b/alohomora_build/src/scrutinizer/mod.rs
@@ -19,25 +19,6 @@ fn remove_vars(cmd: &mut Command) {
     }
 }
 
-fn generate_facts(env: &Env) {
-    warn!("\x1b[96mnote: \x1b[97mGenerating scrutinizer facts....\x1b[0m");
-
-    let mut cmd = Command::new(&env.cargo);
-    remove_vars(&mut cmd);
-
-    let status = cmd
-        .arg("+nightly-2023-04-12")
-        .arg("build")
-        .arg("-Zbuild-std=std,core,alloc,proc_macro")
-        .arg(&format!("--target={}", env.host))
-        .env("RUSTFLAGS", "-Zalways-encode-mir -Znll-facts")
-        .status()
-        .expect("\x1b[91merror: \x1b[97mFailed to generate scrutinizer facts'.\x1b[0m");
-    if !status.success() {
-        panic!("\x1b[91merror: \x1b[97mFailed to generate scrutinizer facts'.\x1b[0m");
-    }
-}
-
 // Run scrutinizer
 fn run_scrutinizer(env: &Env) {
     warn!("\x1b[96mnote: \x1b[97mRunning scrutinizer....\x1b[0m");
@@ -46,9 +27,11 @@ fn run_scrutinizer(env: &Env) {
     remove_vars(&mut cmd);
     
     let status = cmd
-        .arg("+nightly-2023-04-12")
+        .arg("+nightly-2023-08-25")
         .arg("scrutinizer")
         .args(["--config-path", "scrutinizer-config.toml"])
+        .env("RUST_BACKTRACE", "full")
+        .env("RUST_LOG", "scrutinizer=trace,scrutils=trace")
         .status()
         .expect("\x1b[91merror: \x1b[97mFailed to run scrutinizer'.\x1b[0m");
     if !status.success() {
@@ -60,7 +43,6 @@ pub fn scrutinize(env: &Env) {
     let profile = &env.profile;
     if profile == "release" {
         warn!("\x1b[97m    Scrutinizer\x1b[0m");
-        generate_facts(env);
         run_scrutinizer(env);
         warn!("\x1b[92m    Scrutinizer completed!\x1b[0m");
     } else {

--- a/alohomora_lints/Cargo.lock
+++ b/alohomora_lints/Cargo.lock
@@ -558,7 +558,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.22",
+ "semver 1.0.20",
  "serde",
  "serde_json",
  "thiserror",
@@ -809,12 +809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafrog"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0afaad2b26fa326569eb264b1363e8ae3357618c43982b3f285f0774ce76b69"
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,7 +980,7 @@ dependencies = [
  "is-terminal",
  "log",
  "once_cell",
- "semver 1.0.22",
+ "semver 1.0.20",
  "serde",
  "serde_json",
  "tempfile",
@@ -1185,12 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-
-[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,15 +1191,16 @@ dependencies = [
 
 [[package]]
 name = "flowistry"
-version = "0.5.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb65bb165232b9ed2b0829314eee43d20c1d2b7eb9447a593edd8190ff4953b4"
+version = "0.5.41"
+source = "git+https://github.com/brownsys/flowistry?rev=08c4ad9587b3251a8f7c64aa60be31404e6e04c0#08c4ad9587b3251a8f7c64aa60be31404e6e04c0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
  "fluid-let",
+ "indexical",
+ "itertools 0.12.1",
  "log",
- "rustc_utils 0.6.0-nightly-2023-04-12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_utils",
  "serde",
 ]
 
@@ -1436,6 +1425,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1904,6 +1902,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "index_vec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44faf5bb8861a9c72e20d3fb0fdbd59233e43056e2b80475ab0aacdc2e781355"
+
+[[package]]
+name = "indexical"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467e4f95baab3c675f5e42553f822b34e176aa13c322ec8c258743825deaafb6"
+dependencies = [
+ "fxhash",
+ "index_vec",
+ "splitmut",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,7 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2710,12 +2725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordermap"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,16 +2872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-dependencies = [
- "fixedbitset",
- "ordermap",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,17 +2946,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "polonius-engine"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e8e505342045d397d0b6674dcb82d6faf5cf40484d30eeb88fc82ef14e903f"
-dependencies = [
- "datafrog",
- "log",
- "rustc-hash",
-]
 
 [[package]]
 name = "powerfmt"
@@ -3621,23 +3609,13 @@ checksum = "5be1bdc7edf596692617627bbfeaba522131b18e06ca4df2b6b689e3c5d5ce84"
 
 [[package]]
 name = "rustc_utils"
-version = "0.6.0-nightly-2023-04-12"
+version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3935b4a82abe6904308c9273afba6160cf36f20044e720c43839a08519eadfd8"
+checksum = "09428c7086894369685cca54a516acc0f0ab6d0e5a628c094ba83bfddaf1aedf"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
- "intervaltree",
- "log",
-]
-
-[[package]]
-name = "rustc_utils"
-version = "0.6.0-nightly-2023-04-12"
-source = "git+https://github.com/KinanBab/rustc_plugin.git?branch=main#2ee40b343d70df051dd4860d431d2f2e4deac8bb"
-dependencies = [
- "anyhow",
- "cfg-if 1.0.0",
+ "indexical",
  "intervaltree",
  "log",
 ]
@@ -3780,11 +3758,8 @@ dependencies = [
  "flowistry",
  "itertools 0.12.1",
  "log",
- "petgraph",
- "polonius-engine",
  "regex",
- "rustc-hash",
- "rustc_utils 0.6.0-nightly-2023-04-12 (git+https://github.com/KinanBab/rustc_plugin.git?branch=main)",
+ "rustc_utils",
  "serde",
  "serde_json",
  "toml",
@@ -3857,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
@@ -3872,18 +3847,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3892,9 +3867,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -4077,6 +4052,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "splitmut"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85070f382340e8b23a75808e83573ddf65f9ad9143df9573ca37c1ed2ee956a"
 
 [[package]]
 name = "stable-pattern"
@@ -4701,7 +4682,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -29,19 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if 1.0.0",
- "getrandom 0.2.14",
- "once_cell",
- "version_check 0.9.4",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,18 +36,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alohomora"
@@ -86,7 +61,6 @@ dependencies = [
  "rocket_cors",
  "rocket_dyn_templates",
  "rocket_firebase_auth",
- "sea-orm",
  "sea-orm-rocket",
  "serde",
  "serde_json",
@@ -125,7 +99,6 @@ dependencies = [
  "cargo_toml",
  "chrono",
  "serde",
- "serde_json",
  "tinytemplate",
 ]
 
@@ -252,15 +225,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
-]
-
-[[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -397,12 +361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bigdecimal"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,17 +382,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "bigdecimal"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
-dependencies = [
- "num-bigint 0.4.4",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -486,9 +433,6 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitvec"
@@ -782,12 +726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,21 +768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,15 +800,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -942,35 +856,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1059,9 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1128,9 +1017,6 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "email"
@@ -1259,23 +1145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if 1.0.0",
- "home",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,12 +1226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
-
-[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,17 +1234,6 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin 0.9.8",
 ]
 
 [[package]]
@@ -1558,17 +1410,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
-]
-
-[[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -1766,7 +1607,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
 ]
 
 [[package]]
@@ -1775,7 +1616,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
 ]
 
 [[package]]
@@ -1783,28 +1624,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.3",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1820,39 +1639,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "hostname"
@@ -2027,17 +1813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inherent"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,9 +1942,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin 0.5.2",
-]
 
 [[package]]
 name = "lazycell"
@@ -2262,17 +2034,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2415,16 +2176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if 1.0.0",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,12 +2195,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2528,7 +2273,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.8",
+ "spin",
  "tokio",
  "tokio-util 0.7.10",
  "version_check 0.9.4",
@@ -2582,7 +2327,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha1 0.6.1",
+ "sha1",
  "sha2 0.8.2",
  "time 0.2.27",
  "twox-hash",
@@ -2618,7 +2363,7 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha1 0.6.1",
+ "sha1",
  "sha2 0.9.9",
  "smallvec",
  "subprocess",
@@ -2725,16 +2470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "normpath"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,23 +2551,6 @@ dependencies = [
  "autocfg 1.2.0",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -2974,39 +2692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "3.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ouroboros"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ba07320d39dfea882faa70554b4bd342a5f273ed59ba7c1c6b4c840492c954"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
- "static_assertions",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,17 +2705,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3045,19 +2720,6 @@ dependencies = [
  "redox_syscall 0.2.16",
  "smallvec",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall 0.4.1",
- "smallvec",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3123,15 +2785,6 @@ checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.1",
  "serde",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3236,27 +2889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,7 +2924,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check 0.9.4",
 ]
 
@@ -3808,7 +3439,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.14",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3861,7 +3492,7 @@ dependencies = [
  "memchr",
  "multer",
  "num_cpus",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project-lite",
  "rand 0.8.5",
  "ref-cast",
@@ -3952,7 +3583,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pear",
  "percent-encoding",
  "pin-project-lite",
@@ -3964,26 +3595,6 @@ dependencies = [
  "time 0.2.27",
  "tokio",
  "uncased",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
-dependencies = [
- "const-oid",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4106,59 +3717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sea-bae"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd3534a9978d0aa7edd2808dc1f8f31c4d0ecd31ddf71d997b3c98e9f3c9114"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
-name = "sea-orm"
-version = "0.12.15"
-source = "git+https://github.com/KinanBab/sea-orm.git?branch=main#70a69913ab23a49eaa143b333a25756113b3bedf"
-dependencies = [
- "async-stream",
- "async-trait",
- "bigdecimal 0.3.1",
- "chrono",
- "futures",
- "log",
- "ouroboros",
- "rust_decimal",
- "sea-orm-macros",
- "sea-query",
- "sea-query-binder",
- "serde",
- "serde_json",
- "sqlx",
- "strum",
- "thiserror",
- "time 0.3.36",
- "tracing",
- "url",
- "uuid 1.8.0",
-]
-
-[[package]]
-name = "sea-orm-macros"
-version = "0.12.15"
-source = "git+https://github.com/KinanBab/sea-orm.git?branch=main#70a69913ab23a49eaa143b333a25756113b3bedf"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "sea-bae",
- "syn 2.0.58",
- "unicode-ident",
-]
-
-[[package]]
 name = "sea-orm-rocket"
 version = "0.5.4"
 source = "git+https://github.com/KinanBab/sea-orm.git?branch=main#70a69913ab23a49eaa143b333a25756113b3bedf"
@@ -4174,39 +3732,6 @@ source = "git+https://github.com/KinanBab/sea-orm.git?branch=main#70a69913ab23a4
 dependencies = [
  "devise",
  "quote",
-]
-
-[[package]]
-name = "sea-query"
-version = "0.30.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4166a1e072292d46dc91f31617c2a1cdaf55a8be4b5c9f4bf2ba248e3ac4999b"
-dependencies = [
- "bigdecimal 0.3.1",
- "chrono",
- "derivative",
- "inherent",
- "ordered-float",
- "rust_decimal",
- "serde_json",
- "time 0.3.36",
- "uuid 1.8.0",
-]
-
-[[package]]
-name = "sea-query-binder"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36bbb68df92e820e4d5aeb17b4acd5cc8b5d18b2c36a4dd6f4626aabfa7ab1b9"
-dependencies = [
- "bigdecimal 0.3.1",
- "chrono",
- "rust_decimal",
- "sea-query",
- "serde_json",
- "sqlx",
- "time 0.3.36",
- "uuid 1.8.0",
 ]
 
 [[package]]
@@ -4328,17 +3853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4402,16 +3916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4534,253 +4038,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "sqlformat"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
-dependencies = [
- "itertools",
- "nom 7.1.3",
- "unicode_categories",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
-dependencies = [
- "ahash 0.8.11",
- "atoi",
- "bigdecimal 0.3.1",
- "byteorder",
- "bytes 1.6.0",
- "chrono",
- "crc",
- "crossbeam-queue",
- "either",
- "event-listener",
- "futures-channel",
- "futures-core",
- "futures-intrusive",
- "futures-io",
- "futures-util",
- "hashlink",
- "hex",
- "indexmap 2.2.6",
- "log",
- "memchr",
- "native-tls",
- "once_cell",
- "paste",
- "percent-encoding",
- "rust_decimal",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "smallvec",
- "sqlformat",
- "thiserror",
- "time 0.3.36",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
- "uuid 1.8.0",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
-dependencies = [
- "proc-macro2",
- "quote",
- "sqlx-core",
- "sqlx-macros-core",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
-dependencies = [
- "dotenvy",
- "either",
- "heck",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
- "syn 1.0.109",
- "tempfile",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
-dependencies = [
- "atoi",
- "base64 0.21.7",
- "bigdecimal 0.3.1",
- "bitflags 2.5.0",
- "byteorder",
- "bytes 1.6.0",
- "chrono",
- "crc",
- "digest 0.10.7",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array 0.14.7",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand 0.8.5",
- "rsa",
- "rust_decimal",
- "serde",
- "sha1 0.10.6",
- "sha2 0.10.8",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror",
- "time 0.3.36",
- "tracing",
- "uuid 1.8.0",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
-dependencies = [
- "atoi",
- "base64 0.21.7",
- "bigdecimal 0.3.1",
- "bitflags 2.5.0",
- "byteorder",
- "chrono",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "hex",
- "hkdf",
- "hmac",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "num-bigint 0.4.4",
- "once_cell",
- "rand 0.8.5",
- "rust_decimal",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror",
- "time 0.3.36",
- "tracing",
- "uuid 1.8.0",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-sqlite"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
-dependencies = [
- "atoi",
- "chrono",
- "flume",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-intrusive",
- "futures-util",
- "libsqlite3-sys",
- "log",
- "percent-encoding",
- "serde",
- "sqlx-core",
- "time 0.3.36",
- "tracing",
- "url",
- "urlencoding",
- "uuid 1.8.0",
-]
 
 [[package]]
 name = "stable-pattern"
@@ -4854,7 +4114,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1 0.6.1",
+ "sha1",
  "syn 1.0.109",
 ]
 
@@ -4863,17 +4123,6 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
-name = "stringprep"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
-dependencies = [
- "finl_unicode",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "strsim"
@@ -4888,12 +4137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
 name = "subprocess"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,12 +4145,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -5336,7 +4573,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5531,12 +4767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5547,12 +4777,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -5570,12 +4794,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
@@ -5597,9 +4815,6 @@ name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "valuable"
@@ -5667,12 +4882,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -5829,16 +5038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "whoami"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
-dependencies = [
- "redox_syscall 0.4.1",
- "wasite",
 ]
 
 [[package]]
@@ -6110,29 +5309,3 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/harness/plotting.py
+++ b/harness/plotting.py
@@ -152,12 +152,12 @@ def PlotMergedPercentilesNoBreak(baseline, alohomora):
     ax1.set_xticks(X, [PLOT_LABELS[e] for e in ENDPOINTS_PLOT], rotation=15, ha='right', fontsize=8)
     # plt.xlabel("Websubmit Comparison")
 
-    ax1.axvline(x=4.5, color='red', linestyle='--', linewidth=1.5)
+    ax1.axvline(x=4.5, color='black', linestyle='-', linewidth=1.5)
 
     ax1.legend(frameon=False, fontsize=8, ncol=2, handlelength=0.5, handletextpad=0.5, bbox_to_anchor=(0.525, 0.525))
 
     fig.text(0.3, 0.775, 'WebSubmit')
-    fig.text(0.725, 0.775, 'Portfolio')
+    fig.text(0.7175, 0.775, 'Portfolio')
 
     plt.savefig("websubmit.pdf", format="pdf",
                 bbox_inches="tight", pad_inches=0.01)

--- a/harness/plotting.py
+++ b/harness/plotting.py
@@ -7,9 +7,9 @@ import matplotlib
 matplotlib.use("Agg")
 
 SYSTEM_COLORS = {
-    'Baseline': 'C0',
-    'Sesame': 'C1',
-    'Naive Sesame': 'C2',
+    'Baseline': '#0000BC',
+    'Sesame': '#EDB415',
+    'Naive Sesame': '#C944C4',
 }
 
 
@@ -30,14 +30,26 @@ PLOT_LABELS = {
     "predict_grades_bench": "Predict Grades",
     "get_aggregates_bench": "Get Aggregates",
     "get_employer_info_bench": "Get Employer Info",
+    "upload_candidate_details": "Update Candidate",
+    "list_candidates": "List Candidates",
 }
 
-ENDPOINTS = [
+ENDPOINTS_LOAD = [
     "register_users_bench",
     "retrain_model_bench",
     "predict_grades_bench",
     "get_aggregates_bench",
     "get_employer_info_bench",
+]
+
+ENDPOINTS_PLOT = [
+    "register_users_bench",
+    "retrain_model_bench",
+    "predict_grades_bench",
+    "get_aggregates_bench",
+    "get_employer_info_bench",
+    "upload_candidate_details",
+    "list_candidates",
 ]
 
 FOLD_BASELINE_ENDPOINTS = [
@@ -62,7 +74,7 @@ FOLD_ENDPOINTS = [
 
 PERCENTILES = ["50", "95"]
 
-X = np.arange(len(ENDPOINTS))
+X = np.arange(len(ENDPOINTS_PLOT))
 X_F = np.arange(len(FOLD_ENDPOINTS))
 W = 0.3
 
@@ -76,8 +88,8 @@ def PlotMergedPercentiles(baseline, alohomora):
     ax2.set_ylim(0, 0.09)
 
     for percentile in PERCENTILES:
-        b = [baseline[endpoint][percentile] for endpoint in ENDPOINTS]
-        a = [alohomora[endpoint][percentile] for endpoint in ENDPOINTS]
+        b = [baseline[endpoint][percentile] for endpoint in ENDPOINTS_LOAD]
+        a = [alohomora[endpoint][percentile] for endpoint in ENDPOINTS_LOAD]
 
         alpha = 1 if percentile == "50" else 0.3
         label_baseline = "Baseline" if percentile == "50" else None
@@ -102,7 +114,7 @@ def PlotMergedPercentiles(baseline, alohomora):
     ax1.legend(frameon=False, fontsize=8)
 
     ax1.xaxis.set_ticks_position('none')
-    ax2.set_xticks(X, [PLOT_LABELS[e] for e in ENDPOINTS], rotation=15, ha='right')
+    ax2.set_xticks(X, [PLOT_LABELS[e] for e in ENDPOINTS_LOAD], rotation=15, ha='right')
 
     # plt.xlabel("Websubmit Comparison")
     plt.ylabel("Latency [ms]")
@@ -111,10 +123,11 @@ def PlotMergedPercentiles(baseline, alohomora):
 
 # Plot 50th and 95th percentile on one figure
 def PlotMergedPercentilesNoBreak(baseline, alohomora):
-    fig = plt.figure(figsize=(3.33, 1.3))
+    fig, ax1 = plt.subplots(figsize=(3.33, 1.3))
+
     for percentile in PERCENTILES:
-        b = [baseline[endpoint][percentile] for endpoint in ENDPOINTS]
-        a = [alohomora[endpoint][percentile] for endpoint in ENDPOINTS]
+        b = [baseline[endpoint][percentile] for endpoint in ENDPOINTS_PLOT]
+        a = [alohomora[endpoint][percentile] for endpoint in ENDPOINTS_PLOT]
 
         print("at percentile " + percentile + "\n");
         print("\n baseline train is " + str(b) + "\n");
@@ -124,16 +137,28 @@ def PlotMergedPercentilesNoBreak(baseline, alohomora):
         label_baseline = "Baseline" if percentile == "50" else None
         label_alohomora = "Sesame" if percentile == "50" else None
 
-        plt.bar(X - 0.5 * W, b, W, label=label_baseline,
+        ax1.bar(X - 0.5 * W, b, W, label=label_baseline,
                 color=SYSTEM_COLORS['Baseline'], alpha=alpha)
-        plt.bar(X + 0.5 * W, a, W, label=label_alohomora,
+        ax1.bar(X + 0.5 * W, a, W, label=label_alohomora,
                 color=SYSTEM_COLORS['Sesame'], alpha=alpha)
+        
+    ax1.set_ylim(ymax=12.5)
+    
+    ax2 = ax1.twinx()
+    ax2.set_ylim(ymax=37.5)
+    ax2.set_yticks([0, 10, 20, 30])
 
-    plt.ylabel("Latency [ms]", loc="center")
-    plt.xticks(X, [PLOT_LABELS[e] for e in ENDPOINTS], rotation=15, ha='right')
+    ax1.set_ylabel("Latency [ms]", loc="center")
+    ax1.set_xticks(X, [PLOT_LABELS[e] for e in ENDPOINTS_PLOT], rotation=15, ha='right', fontsize=8)
     # plt.xlabel("Websubmit Comparison")
-    plt.ylim(ymax=11)
-    plt.legend(frameon=False, fontsize=8)
+
+    ax1.axvline(x=4.5, color='red', linestyle='--', linewidth=1.5)
+
+    ax1.legend(frameon=False, fontsize=8, ncol=2, handlelength=0.5, handletextpad=0.5, bbox_to_anchor=(0.525, 0.525))
+
+    fig.text(0.3, 0.775, 'WebSubmit')
+    fig.text(0.725, 0.775, 'Portfolio')
+
     plt.savefig("websubmit.pdf", format="pdf",
                 bbox_inches="tight", pad_inches=0.01)
 
@@ -191,11 +216,11 @@ def PlotFoldPercentiles(baseline, alohomora, naive):
 
 # Plot 50th and 95th percentile on one figure
 def PlotMeanAndStd(baseline, alohomora):
-    b_mean = [baseline[endpoint]['mean'] for endpoint in ENDPOINTS]
-    a_mean = [alohomora[endpoint]['mean'] for endpoint in ENDPOINTS]
+    b_mean = [baseline[endpoint]['mean'] for endpoint in ENDPOINTS_LOAD]
+    a_mean = [alohomora[endpoint]['mean'] for endpoint in ENDPOINTS_LOAD]
 
-    b_std = [baseline[endpoint]['std'] for endpoint in ENDPOINTS]
-    a_std = [alohomora[endpoint]['std'] for endpoint in ENDPOINTS]
+    b_std = [baseline[endpoint]['std'] for endpoint in ENDPOINTS_LOAD]
+    a_std = [alohomora[endpoint]['std'] for endpoint in ENDPOINTS_LOAD]
 
     label_baseline = "Baseline"
     label_alohomora = "Sesame"
@@ -206,7 +231,7 @@ def PlotMeanAndStd(baseline, alohomora):
             color=SYSTEM_COLORS['Sesame'], linestyle='None', marker='o', markersize=1)
 
     plt.ylabel("Latency [ms]")
-    plt.xticks(X, [PLOT_LABELS[e] for e in ENDPOINTS], rotation=25, ha='right')
+    plt.xticks(X, [PLOT_LABELS[e] for e in ENDPOINTS_LOAD], rotation=25, ha='right')
     # plt.xlabel("Websubmit Comparison")
     plt.ylim(ymax=20)
     plt.legend(frameon=False, loc='upper left')
@@ -217,7 +242,7 @@ def PlotMeanAndStd(baseline, alohomora):
 def ParseWebsubmitFiles(dir):
     data = dict()
 
-    for endpoint in ENDPOINTS:
+    for endpoint in ENDPOINTS_LOAD:
         df = pd.read_json(dir + "/" + endpoint + ".json")[0] / 1000000
 
         data[endpoint] = dict()
@@ -233,7 +258,7 @@ def ParseWebsubmitFiles(dir):
 def ParseWebsubmitBoxedFiles(dir):
     data = dict()
 
-    for endpoint in ENDPOINTS:
+    for endpoint in ENDPOINTS_LOAD:
         df = pd.read_json(dir + "/" + "boxed_" +
                           endpoint + ".json")[0] / 1000000
 
@@ -294,12 +319,16 @@ if __name__ == "__main__":
 
     # Parse input data.
     baseline = ParseWebsubmitFiles('benches')
+    baseline.update({"upload_candidate_details": {"50": 15.262/3, "95": 25.732/3, "mean": 0, "std": 0}, "list_candidates": {"50": 8.332/3, "95": 9.126/3, "mean": 0, "std": 0}})
+
     alohomora = ParseWebsubmitBoxedFiles('benches')
+    alohomora.update({"upload_candidate_details": {"50": 19.179/3, "95": 30.589/3, "mean": 0, "std": 0}, "list_candidates": {"50": 9.239/3, "95": 9.981/3, "mean": 0, "std": 0}})
+    print(baseline, alohomora)
 
     fold_baseline = ParseFoldWebsubmitFiles('benches')
     fold_alohomora = ParseFoldWebsubmitBoxedFiles('benches')
     fold_naive = ParseFoldWebsubmitNaiveFiles('benches')
-
+    
     # Plot output.
     # PlotMergedPercentiles(baseline, alohomora)
     PlotMergedPercentilesNoBreak(baseline, alohomora)

--- a/websubmit_boxed/Cargo.lock
+++ b/websubmit_boxed/Cargo.lock
@@ -99,7 +99,6 @@ dependencies = [
  "cargo_toml",
  "chrono",
  "serde",
- "serde_json",
  "tinytemplate",
 ]
 
@@ -1834,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.0"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
@@ -1937,7 +1936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4541,7 +4540,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/websubmit_boxed/build.rs
+++ b/websubmit_boxed/build.rs
@@ -1,5 +1,5 @@
 extern crate alohomora_build;
 
 fn main() {
-    alohomora_build::alohomora_build(false, &["../websubmit_boxed_sandboxes"]);
+    alohomora_build::alohomora_build(true, &["../websubmit_boxed_sandboxes"]);
 }

--- a/websubmit_boxed/scrutinizer-config.toml
+++ b/websubmit_boxed/scrutinizer-config.toml
@@ -1,5 +1,5 @@
 mode = "ppr"
-only_inconsistent = true
+only_inconsistent = false
 output_file = "scrutinizer.result.json"
 
 # We only want the first argument to the closure to be treated as important
@@ -144,6 +144,7 @@ allowlist = [
 
   # Raw equality comparison.
   'core\[\w*\]::intrinsics::\{extern#0\}::raw_eq',
+  'core\[\w*\]::intrinsics::\{extern#0\}::compare_bytes',
 
   # Vtable.
   'core\[\w*\]::intrinsics::\{extern#0\}::vtable_size',
@@ -163,7 +164,11 @@ allowlist = [
   'core\[\w*\]::intrinsics::\{extern#0\}::type_id',
   'core\[\w*\]::intrinsics::\{extern#0\}::type_name',
 
+  # Transmute is allowlisted as an intrinsic, but is checked for separately.
+  'core\[\w*\]::intrinsics::\{extern#0\}::transmute',
+
   # Panicking infrastructure.
+  'core\[\w*\]::panicking::assert_failed',
   'core\[\w*\]::panicking::const_panic_fmt',
   'core\[\w*\]::panicking::panic',
   'core\[\w*\]::panicking::panic_display',
@@ -193,9 +198,27 @@ allowlist = [
   # Rust 1.70 calls to memcmp to compare slices.
   # This is removed in further versions.
   'core\[\w*\]::slice::cmp::\{extern#0\}::memcmp',
+
+  # Architecture-dependent intrinsics.
+  'core\[\w*\]::core_arch',
+
+  # Pointer-address conversion primitives.
+  'core\[\w*\]::ptr::invalid',
+  'core\[\w*\]::ptr::invalid_mut',
+  'core\[\w*\]::ptr::const_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::mut_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::alignment::\{impl#0\}::new_unchecked',
 ]
 trusted_stdlib = [
+  # Vec collection.
   'alloc\[\w*\]::vec',
+  # Slice.
   'alloc\[\w*\]::slice',
+  'core\[\w*\]::slice',
+  # String.
+  'alloc\[\w*\]::string',
+  # Hashmap.
   'std\[\w*\]::collections::hash::map',
+  # Btreemap.
+  'alloc\[\w*\]::collections::btree'
 ]

--- a/youchat/scrutinizer-config.toml
+++ b/youchat/scrutinizer-config.toml
@@ -144,6 +144,7 @@ allowlist = [
 
   # Raw equality comparison.
   'core\[\w*\]::intrinsics::\{extern#0\}::raw_eq',
+  'core\[\w*\]::intrinsics::\{extern#0\}::compare_bytes',
 
   # Vtable.
   'core\[\w*\]::intrinsics::\{extern#0\}::vtable_size',
@@ -163,7 +164,11 @@ allowlist = [
   'core\[\w*\]::intrinsics::\{extern#0\}::type_id',
   'core\[\w*\]::intrinsics::\{extern#0\}::type_name',
 
+  # Transmute is allowlisted as an intrinsic, but is checked for separately.
+  'core\[\w*\]::intrinsics::\{extern#0\}::transmute',
+
   # Panicking infrastructure.
+  'core\[\w*\]::panicking::assert_failed',
   'core\[\w*\]::panicking::const_panic_fmt',
   'core\[\w*\]::panicking::panic',
   'core\[\w*\]::panicking::panic_display',
@@ -193,9 +198,27 @@ allowlist = [
   # Rust 1.70 calls to memcmp to compare slices.
   # This is removed in further versions.
   'core\[\w*\]::slice::cmp::\{extern#0\}::memcmp',
+
+  # Architecture-dependent intrinsics.
+  'core\[\w*\]::core_arch',
+
+  # Pointer-address conversion primitives.
+  'core\[\w*\]::ptr::invalid',
+  'core\[\w*\]::ptr::invalid_mut',
+  'core\[\w*\]::ptr::const_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::mut_ptr::\{impl#0\}::addr',
+  'core\[\w*\]::ptr::alignment::\{impl#0\}::new_unchecked',
 ]
 trusted_stdlib = [
+  # Vec collection.
   'alloc\[\w*\]::vec',
+  # Slice.
   'alloc\[\w*\]::slice',
+  'core\[\w*\]::slice',
+  # String.
+  'alloc\[\w*\]::string',
+  # Hashmap.
   'std\[\w*\]::collections::hash::map',
+  # Btreemap.
+  'alloc\[\w*\]::collections::btree'
 ]


### PR DESCRIPTION
- Scripts in `alohomora_build` are now using the updated version of the compiler and do not do redundant fact generation.
- `Cargo.lock` for multiple crates has been updated to feature versions that are compatible with the new compiler version.
- Scrutinizer configuration has been updated to include the changes to the allowlist.
- Plotting scripts have been updated to produce the plots featured in the paper.