### PR TITLE
Update SesameType derive macro

### DIFF
--- a/alohomora/src/bbox/bbox_type.rs
+++ b/alohomora/src/bbox/bbox_type.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;
@@ -278,6 +279,11 @@ impl<T, P: Specializable> BBox<T, P> {
             Ok(p) => Ok(BBox { fb, p }),
             Err(p) => Err(BBox { fb, p }),
         }
+    }
+}
+impl<T> Debug for BBox<T, SpecializationEnum> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.policy().fmt(f)
     }
 }
 

--- a/alohomora/src/db/connection.rs
+++ b/alohomora/src/db/connection.rs
@@ -9,6 +9,7 @@ use crate::policy::Reason;
 use mysql::prelude::Queryable;
 pub use mysql::Opts as BBoxOpts;
 pub use mysql::Result as BBoxResult;
+use crate::sesame_type::r#type::SesameTypeOut;
 
 // BBox DB connection
 pub struct BBoxConn {
@@ -128,9 +129,13 @@ impl BBoxConn {
     }
 }
 
+#[doc = "Library implementation of SesameTypeOut. Do not copy this docstring!"]
+impl SesameTypeOut for BBoxConn {
+    type Out = mysql::Conn;
+}
+
 #[doc = "Library implementation of AlohomoraType. Do not copy this docstring!"]
 impl SesameType for BBoxConn {
-    type Out = mysql::Conn;
     fn to_enum(self) -> SesameTypeEnum {
         SesameTypeEnum::Value(Box::new(self))
     }

--- a/alohomora/src/fold.rs
+++ b/alohomora/src/fold.rs
@@ -148,6 +148,7 @@ mod tests {
     use crate::context::UnprotectedContext;
     use std::collections::{HashMap, HashSet};
     use std::iter::FromIterator;
+    use crate::sesame_type::r#type::SesameTypeOut;
 
     #[derive(Clone, PartialEq, Debug)]
     pub struct ACLPolicy {
@@ -207,9 +208,13 @@ mod tests {
         pub z: String,
     }
 
+    #[doc = "Library implementation of SesameTypeOut. Do not copy this docstring!"]
+    impl SesameTypeOut for BoxedStruct {
+        type Out = BoxedStructLite;
+    }
+
     #[doc = "Library implementation of AlohomoraType. Do not copy this docstring!"]
     impl SesameType for BoxedStruct {
-        type Out = BoxedStructLite;
         fn to_enum(self) -> SesameTypeEnum {
             let hashmap = HashMap::from([
                 (String::from("x"), self.x.to_enum()),

--- a/alohomora/src/lib.rs
+++ b/alohomora/src/lib.rs
@@ -35,7 +35,7 @@ pub mod unbox;
 // Export this directly under sesame::
 mod sesame_type;
 
-pub use sesame_type::{dyns as sesame_type_dyns, r#enum::SesameTypeEnum, r#type::SesameType};
+pub use sesame_type::{dyns as sesame_type_dyns, r#enum::SesameTypeEnum, r#type::SesameType, r#type::SesameTypeOut};
 
 #[cfg(feature = "alohomora_derive")]
-pub use alohomora_derive::SesameTypeDyn;
+pub use alohomora_derive::SesameType;

--- a/alohomora/src/sesame_type/type.rs
+++ b/alohomora/src/sesame_type/type.rs
@@ -3,10 +3,14 @@ use crate::sesame_type::dyns::SesameDyn;
 use crate::sesame_type::r#enum::SesameTypeEnum;
 use std::any::Any;
 
+pub trait SesameTypeOut {
+    // Unboxed form of struct
+    type Out;
+}
+
 // Public: client code should derive this for structs that they want to unbox, fold, or pass to
 // sandboxes.
-pub trait SesameType<T: SesameDyn + ?Sized = dyn Any, P: PolicyDyn + ?Sized = dyn AnyPolicyDyn> {
-    type Out; // Unboxed form of struct
+pub trait SesameType<T: SesameDyn + ?Sized = dyn Any, P: PolicyDyn + ?Sized = dyn AnyPolicyDyn> : SesameTypeOut {
     fn to_enum(self) -> SesameTypeEnum<T, P>;
     fn from_enum(e: SesameTypeEnum<T, P>) -> Result<Self::Out, ()>;
 }

--- a/alohomora/src/testing/test_context.rs
+++ b/alohomora/src/testing/test_context.rs
@@ -4,6 +4,7 @@ use crate::policy::NoPolicy;
 use crate::rocket::{BBoxRequest, BBoxRequestOutcome, FromBBoxRequest};
 use crate::{SesameType, SesameTypeEnum};
 use std::any::Any;
+use crate::sesame_type::r#type::SesameTypeOut;
 
 #[derive(Clone)]
 pub struct TestContextData<T: Send + Any>(BBox<T, NoPolicy>);
@@ -14,10 +15,13 @@ impl<T: Send + Any> TestContextData<T> {
     }
 }
 
+#[doc = "Library implementation of SesameTypeOut. Do not copy this docstring!"]
+impl<T: Send + Any> SesameTypeOut for TestContextData<T> {
+    type Out = T;
+}
+
 #[doc = "Library implementation of AlohomoraType. Do not copy this docstring!"]
 impl<T: Send + Any> SesameType for TestContextData<T> {
-    type Out = T;
-
     fn to_enum(self) -> SesameTypeEnum {
         SesameTypeEnum::BBox(self.0.into_any_no_clone())
     }

--- a/alohomora/tests/application/context.rs
+++ b/alohomora/tests/application/context.rs
@@ -1,9 +1,8 @@
 use alohomora::bbox::BBox;
 use alohomora::context::Context;
 use alohomora::rocket::{BBoxCookie, BBoxRequest, BBoxRequestOutcome, FromBBoxRequest};
-use alohomora::{SesameType, SesameTypeEnum};
+use alohomora::{SesameType, SesameTypeEnum, SesameTypeOut};
 use rocket::async_trait;
-use std::any::Any;
 
 use crate::application::policy::AuthenticationCookiePolicy;
 
@@ -16,8 +15,10 @@ pub struct ContextData {
 // Application contexts.
 pub type AppContext = Context<ContextData>;
 
-impl SesameType<dyn Any> for ContextData {
+impl SesameTypeOut for ContextData {
     type Out = Option<String>;
+}
+impl SesameType for ContextData {
     fn to_enum(self) -> SesameTypeEnum {
         self.user.to_enum()
     }

--- a/alohomora/tests/application/policy.rs
+++ b/alohomora/tests/application/policy.rs
@@ -1,4 +1,4 @@
-use alohomora::SesameType;
+use alohomora::SesameTypeOut;
 use cookie::Cookie;
 use mysql::{from_value, Value};
 use rocket::Request;
@@ -20,7 +20,7 @@ impl SimplePolicy for ACLPolicy {
         String::from("ACLPolicy")
     }
     fn simple_check(&self, context: &UnprotectedContext, _: Reason) -> bool {
-        type ContextDataOut = <ContextData as SesameType>::Out;
+        type ContextDataOut = <ContextData as SesameTypeOut>::Out;
         let r: &ContextDataOut = context.downcast_ref().unwrap();
         match r {
             None => false,
@@ -85,7 +85,7 @@ impl Policy for WritePolicy {
         match reason {
             Reason::DB(stmt, _) => {
                 if stmt.starts_with("INSERT") {
-                    type ContextDataOut = <ContextData as SesameType>::Out;
+                    type ContextDataOut = <ContextData as SesameTypeOut>::Out;
                     let r: &ContextDataOut = context.downcast_ref().unwrap();
                     match r {
                         None => false,

--- a/alohomora_derive/Cargo.lock
+++ b/alohomora_derive/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "alohomora_sandbox",
  "chrono",
  "cookie",
+ "dyn-clone",
  "dynfmt",
  "either",
  "erased-serde",
@@ -822,6 +823,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynfmt"

--- a/alohomora_derive/src/alohomora_type.rs
+++ b/alohomora_derive/src/alohomora_type.rs
@@ -1,4 +1,3 @@
-// TODO(babman): clean this up, and make it work for different super traits and dyns.
 extern crate proc_macro2;
 extern crate quote;
 extern crate syn;
@@ -9,7 +8,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren, Pound};
-use syn::{Data, DeriveInput, Fields, Type, ItemStruct, Attribute, AttrStyle, Meta, MetaList, PathSegment, Path, MacroDelimiter, PathArguments, FieldsNamed};
+use syn::{Data, DeriveInput, Fields, Type, ItemStruct, Attribute, AttrStyle, Meta, MetaList, PathSegment, Path, MacroDelimiter, PathArguments, FieldsNamed, Generics, Token, GenericParam, TypeParam, TypeParamBound, TraitBound, TraitBoundModifier, WhereClause, WherePredicate, PredicateType, AngleBracketedGenericArguments, GenericArgument, TypePath};
 use attribute_derive::FromAttr;
 
 pub type Error = (Span, &'static str);
@@ -36,6 +35,181 @@ impl AlohomoraTypeArgs {
             },
         }
     }
+}
+
+fn make_tdyn() -> GenericParam {
+    GenericParam::Type(TypeParam {
+        attrs: Vec::new(),
+        ident: Ident::new("__TDyn", Span::mixed_site()),
+        colon_token: Default::default(),
+        bounds: Punctuated::from_iter([
+            TypeParamBound::Trait(
+                TraitBound {
+                    paren_token: None,
+                    modifier: TraitBoundModifier::None,
+                    lifetimes: None,
+                    path: Path {
+                        leading_colon: Some(Default::default()),
+                        segments: Punctuated::from_iter([
+                            PathSegment {
+                                ident: Ident::new("alohomora", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            },
+                            PathSegment {
+                                ident: Ident::new("sesame_type_dyns", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            },
+                            PathSegment {
+                                ident: Ident::new("SesameDyn", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            }
+                        ])
+                    }
+                }
+            ),
+            TypeParamBound::Trait(
+                TraitBound {
+                    paren_token: None,
+                    modifier: TraitBoundModifier::Maybe(Default::default()),
+                    lifetimes: None,
+                    path: Path {
+                        leading_colon: None,
+                        segments: Punctuated::from_iter([
+                            PathSegment {
+                                ident: Ident::new("Sized", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            }
+                        ])
+                    }
+                }
+            )
+        ]),
+        eq_token: None,
+        default: None,
+    })
+}
+fn make_pdyn() -> GenericParam {
+    GenericParam::Type(TypeParam {
+        attrs: Vec::new(),
+        ident: Ident::new("__PDyn", Span::mixed_site()),
+        colon_token: Default::default(),
+        bounds: Punctuated::from_iter([
+            TypeParamBound::Trait(
+                TraitBound {
+                    paren_token: None,
+                    modifier: TraitBoundModifier::None,
+                    lifetimes: None,
+                    path: Path {
+                        leading_colon: Some(Default::default()),
+                        segments: Punctuated::from_iter([
+                            PathSegment {
+                                ident: Ident::new("alohomora", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            },
+                            PathSegment {
+                                ident: Ident::new("policy", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            },
+                            PathSegment {
+                                ident: Ident::new("PolicyDyn", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            }
+                        ])
+                    }
+                }
+            ),
+            TypeParamBound::Trait(
+                TraitBound {
+                    paren_token: None,
+                    modifier: TraitBoundModifier::Maybe(Default::default()),
+                    lifetimes: None,
+                    path: Path {
+                        leading_colon: None,
+                        segments: Punctuated::from_iter([
+                            PathSegment {
+                                ident: Ident::new("Sized", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            }
+                        ])
+                    }
+                }
+            )
+        ]),
+        eq_token: None,
+        default: None,
+    })
+}
+
+// Create a where clause bound on the form
+// $field_type: ::alohomora::SesameType<__TDyn, __PDyn>
+fn sesame_type_where_clause(field_type: &Type) -> WherePredicate {
+    WherePredicate::Type(PredicateType {
+        lifetimes: None,
+        bounded_ty: field_type.clone(),
+        colon_token: Default::default(),
+        bounds: Punctuated::from_iter([
+            TypeParamBound::Trait(
+                TraitBound {
+                    paren_token: None,
+                    modifier: TraitBoundModifier::None,
+                    lifetimes: None,
+                    path: Path {
+                        leading_colon: Some(Default::default()),
+                        segments: Punctuated::from_iter([
+                            PathSegment {
+                                ident: Ident::new("alohomora", Span::mixed_site()),
+                                arguments: PathArguments::None,
+                            },
+                            PathSegment {
+                                ident: Ident::new("SesameType", Span::mixed_site()),
+                                arguments: PathArguments::AngleBracketed(
+                                    AngleBracketedGenericArguments {
+                                        colon2_token: Default::default(),
+                                        lt_token: Default::default(),
+                                        args: Punctuated::from_iter([
+                                            GenericArgument::Type(
+                                                Type::Path(
+                                                    TypePath {
+                                                        qself: None,
+                                                        path: Path {
+                                                            leading_colon: None,
+                                                            segments: Punctuated::from_iter([
+                                                                PathSegment {
+                                                                    ident: Ident::new("__TDyn", Span::mixed_site()),
+                                                                    arguments: PathArguments::None,
+                                                                }
+                                                            ])
+                                                        }
+                                                    }
+                                                )
+                                            ),
+                                            GenericArgument::Type(
+                                                Type::Path(
+                                                    TypePath {
+                                                        qself: None,
+                                                        path: Path {
+                                                            leading_colon: None,
+                                                            segments: Punctuated::from_iter([
+                                                                PathSegment {
+                                                                    ident: Ident::new("__PDyn", Span::mixed_site()),
+                                                                    arguments: PathArguments::None,
+                                                                }
+                                                            ])
+                                                        }
+                                                    }
+                                                )
+                                            )
+                                        ]),
+                                        gt_token: Default::default(),
+                                    }
+                                ),
+                            },
+                        ])
+                    }
+                }
+            )]
+        )
+    })
 }
 
 // Generate #[derive(...)] for all the required traits for the output type.
@@ -70,8 +244,8 @@ fn derive_traits_for_output_type(attrs: &AlohomoraTypeArgs) -> Option<Attribute>
 // Parse DeriveInput to a struct.
 pub fn parse_derive_input_struct(input: DeriveInput) -> Result<ItemStruct, Error> {
     match input.data {
-        Data::Enum(_) => Err((input.ident.span(), "derive(AlohomoraType) only works on structs")),
-        Data::Union(_) => Err((input.ident.span(), "derive(AlohomoraType) only works on structs")),
+        Data::Enum(_) => Err((input.ident.span(), "derive(SesameType) only works on structs")),
+        Data::Union(_) => Err((input.ident.span(), "derive(SesameType) only works on structs")),
         Data::Struct(data_struct) => Ok(
             ItemStruct {
                 attrs: input.attrs,
@@ -98,7 +272,7 @@ fn construct_out_fields(input: &ItemStruct, attrs: &AlohomoraTypeArgs) -> Result
                         let ty = &field.ty;
                         if !attrs.is_verbatim(&field.ident.as_ref().unwrap().to_string()) {
                             field.ty = Type::Verbatim(quote! {
-                                <#ty as ::alohomora::SesameTypeDyn<::std::any::Any>>::Out
+                                <#ty as ::alohomora::SesameTypeOut>::Out
                             });
                         }
                         field
@@ -106,7 +280,7 @@ fn construct_out_fields(input: &ItemStruct, attrs: &AlohomoraTypeArgs) -> Result
                     .collect(),
             })
         ),
-        _ => Err((input.ident.span(), "derive(AlohomoraType) only works on structs with named fields"))
+        _ => Err((input.ident.span(), "derive(SesameType) only works on structs with named fields"))
     }
 }
 
@@ -121,23 +295,20 @@ fn construct_out_type(input: &ItemStruct, attrs: &AlohomoraTypeArgs) -> Result<I
         None => Ident::new(&format!("{}Out", input.ident), Span::mixed_site()),
         Some(name) => name.clone(),
     };
-    result.fields = construct_out_fields(input, attrs)?;
+    result.fields = construct_out_fields(&input, attrs)?;
     Ok(result)
 }
 
 
-pub fn derive_alohomora_type_impl(input: DeriveInput) -> Result<TokenStream, Error> {
+pub fn derive_sesame_type_impl(input: DeriveInput) -> Result<TokenStream, Error> {
     // Parse the provided input attributes.
     let attrs = AlohomoraTypeArgs::from_attributes(&input.attrs).unwrap();
 
     // Parse the input struct.
-    let input = parse_derive_input_struct(input)?;
+    let mut input = parse_derive_input_struct(input)?;
 
     // Construct the output struct.
     let out = construct_out_type(&input, &attrs)?;
-
-    // The generics of the input type.
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     // Expand needed variables.
     let input_ident = &input.ident;
@@ -187,27 +358,55 @@ pub fn derive_alohomora_type_impl(input: DeriveInput) -> Result<TokenStream, Err
         .map(|(_, string, _)| string.clone())
         .collect();
 
+    // Store type traits prior to adding our own __TDyn and __PDyn
+    let (impl_generics_out, ty_generics, where_clause_out) = input.generics.split_for_impl();
+
+    // Add trait bounds for SesameDyn and PolicyDyn.
+    let mut input = input.clone();
+    input.generics.params.push(make_tdyn());
+    input.generics.params.push(make_pdyn());
+
+    // Add where clause bounds for each inner type.
+    if input.generics.where_clause.is_none() {
+        input.generics.where_clause = Some(WhereClause {
+            where_token: Default::default(),
+            predicates: Punctuated::new()
+        })
+    }
+    let where_clause = input.generics.where_clause.as_mut().unwrap();
+    for field_type in &alohomora_fields_types {
+        where_clause.predicates.push(sesame_type_where_clause(field_type));
+    }
+
+    // The generics of the input type.
+    let (impl_generics, _, where_clause) = input.generics.split_for_impl();
+
     // Generate implementation.
     Ok(quote! {
         #[automatically_derived]
         #out
 
         #[automatically_derived]
-        #[doc = "Library implementation of AlohomoraType. Do not copy this docstring!"]
-        impl #impl_generics ::alohomora::SesameTypeDyn<dyn ::std::any::Any> for #input_ident #ty_generics #where_clause {
+        #[doc = "Library implementation of SesameTypeOut. Do not copy this docstring!"]
+        impl #impl_generics_out ::alohomora::SesameTypeOut  for #input_ident #ty_generics #where_clause_out {
             type Out = #out_ident;
-            fn to_enum(self) -> ::alohomora::SesameTypeEnum {
+        }
+
+        #[automatically_derived]
+        #[doc = "Library implementation of AlohomoraType. Do not copy this docstring!"]
+        impl #impl_generics ::alohomora::SesameType<__TDyn, __PDyn>  for #input_ident #ty_generics #where_clause {
+            fn to_enum(self) -> ::alohomora::SesameTypeEnum<__TDyn, __PDyn>  {
                 let mut map: ::std::collections::HashMap<::std::string::String, ::alohomora::SesameTypeEnum> = ::std::collections::HashMap::new();
                 ::alohomora::SesameTypeEnum::Struct(::std::collections::HashMap::from([
-                    #((String::from(#alohomora_fields_strings), <#alohomora_fields_types as ::alohomora::SesameTypeDyn<dyn ::std::any::Any>>::to_enum(self.#alohomora_fields_idents)),)*
+                    #((String::from(#alohomora_fields_strings), <#alohomora_fields_types as ::alohomora::SesameType<__TDyn, __PDyn> >::to_enum(self.#alohomora_fields_idents)),)*
                     #((String::from(#verbatim_fields_strings), ::alohomora::SesameTypeEnum::Value(Box::new(self.#verbatim_fields_idents))),)*
                 ]))
             }
-            fn from_enum(e: ::alohomora::SesameTypeEnum) -> Result<Self::Out, ()> {
+            fn from_enum(e: ::alohomora::SesameTypeEnum<__TDyn, __PDyn> ) -> Result<Self::Out, ()> {
                 match e {
                     ::alohomora::SesameTypeEnum::Struct(mut hashmap) => {
                         Ok(Self::Out {
-                            #(#alohomora_fields_idents: <#alohomora_fields_types as ::alohomora::SesameTypeDyn<dyn ::std::any::Any>>::from_enum(hashmap.remove(#alohomora_fields_strings).unwrap())?,)*
+                            #(#alohomora_fields_idents: <#alohomora_fields_types as ::alohomora::SesameType<__TDyn, __PDyn> >::from_enum(hashmap.remove(#alohomora_fields_strings).unwrap())?,)*
                             #(#verbatim_fields_idents: hashmap.remove(#verbatim_fields_strings).unwrap().coerce()?,)*
                         })
                     },

--- a/alohomora_derive/src/alohomora_type.rs
+++ b/alohomora_derive/src/alohomora_type.rs
@@ -4,12 +4,16 @@ extern crate syn;
 
 use std::iter::FromIterator;
 
+use attribute_derive::FromAttr;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::punctuated::Punctuated;
-use syn::token::{Brace, Bracket, Paren, Pound};
-use syn::{Data, DeriveInput, Fields, Type, ItemStruct, Attribute, AttrStyle, Meta, MetaList, PathSegment, Path, MacroDelimiter, PathArguments, FieldsNamed, Token, GenericParam, TypeParam, TypeParamBound, TraitBound, TraitBoundModifier, WhereClause, WherePredicate, PredicateType, AngleBracketedGenericArguments, GenericArgument, TypePath, ImplGenerics, TypeGenerics};
-use attribute_derive::{ConvertParsed, FromAttr};
+use syn::token::{Brace, Bracket, Paren};
+use syn::{
+    AngleBracketedGenericArguments, AttrStyle, Attribute, Data, DeriveInput, Fields, FieldsNamed,
+    GenericArgument, GenericParam, ItemStruct, MacroDelimiter, Meta, MetaList, Path,
+    PathArguments, PathSegment, PredicateType, TraitBound, TraitBoundModifier, Type, TypeParam, TypeParamBound, TypePath, WhereClause, WherePredicate,
+};
 
 pub type Error = (Span, &'static str);
 
@@ -17,9 +21,9 @@ pub type Error = (Span, &'static str);
 #[derive(FromAttr)]
 #[attribute(ident = alohomora_out_type)]
 struct AlohomoraTypeArgs {
-  name: Option<Ident>,
-  to_derive: Option<Vec<Ident>>,
-  verbatim: Option<Vec<Ident>>,
+    name: Option<Ident>,
+    to_derive: Option<Vec<Ident>>,
+    verbatim: Option<Vec<Ident>>,
 }
 impl AlohomoraTypeArgs {
     pub fn is_verbatim(&self, ident: &str) -> bool {
@@ -32,7 +36,7 @@ impl AlohomoraTypeArgs {
                     }
                 }
                 false
-            },
+            }
         }
     }
 }
@@ -43,46 +47,40 @@ fn make_tdyn() -> GenericParam {
         ident: Ident::new("__TDyn", Span::mixed_site()),
         colon_token: Default::default(),
         bounds: Punctuated::from_iter([
-            TypeParamBound::Trait(
-                TraitBound {
-                    paren_token: None,
-                    modifier: TraitBoundModifier::None,
-                    lifetimes: None,
-                    path: Path {
-                        leading_colon: Some(Default::default()),
-                        segments: Punctuated::from_iter([
-                            PathSegment {
-                                ident: Ident::new("alohomora", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("sesame_type_dyns", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("SesameDyn", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            }
-                        ])
-                    }
-                }
-            ),
-            TypeParamBound::Trait(
-                TraitBound {
-                    paren_token: None,
-                    modifier: TraitBoundModifier::Maybe(Default::default()),
-                    lifetimes: None,
-                    path: Path {
-                        leading_colon: None,
-                        segments: Punctuated::from_iter([
-                            PathSegment {
-                                ident: Ident::new("Sized", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            }
-                        ])
-                    }
-                }
-            )
+            TypeParamBound::Trait(TraitBound {
+                paren_token: None,
+                modifier: TraitBoundModifier::None,
+                lifetimes: None,
+                path: Path {
+                    leading_colon: Some(Default::default()),
+                    segments: Punctuated::from_iter([
+                        PathSegment {
+                            ident: Ident::new("alohomora", Span::mixed_site()),
+                            arguments: PathArguments::None,
+                        },
+                        PathSegment {
+                            ident: Ident::new("sesame_type_dyns", Span::mixed_site()),
+                            arguments: PathArguments::None,
+                        },
+                        PathSegment {
+                            ident: Ident::new("SesameDyn", Span::mixed_site()),
+                            arguments: PathArguments::None,
+                        },
+                    ]),
+                },
+            }),
+            TypeParamBound::Trait(TraitBound {
+                paren_token: None,
+                modifier: TraitBoundModifier::Maybe(Default::default()),
+                lifetimes: None,
+                path: Path {
+                    leading_colon: None,
+                    segments: Punctuated::from_iter([PathSegment {
+                        ident: Ident::new("Sized", Span::mixed_site()),
+                        arguments: PathArguments::None,
+                    }]),
+                },
+            }),
         ]),
         eq_token: None,
         default: None,
@@ -94,46 +92,40 @@ fn make_pdyn() -> GenericParam {
         ident: Ident::new("__PDyn", Span::mixed_site()),
         colon_token: Default::default(),
         bounds: Punctuated::from_iter([
-            TypeParamBound::Trait(
-                TraitBound {
-                    paren_token: None,
-                    modifier: TraitBoundModifier::None,
-                    lifetimes: None,
-                    path: Path {
-                        leading_colon: Some(Default::default()),
-                        segments: Punctuated::from_iter([
-                            PathSegment {
-                                ident: Ident::new("alohomora", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("policy", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("PolicyDyn", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            }
-                        ])
-                    }
-                }
-            ),
-            TypeParamBound::Trait(
-                TraitBound {
-                    paren_token: None,
-                    modifier: TraitBoundModifier::Maybe(Default::default()),
-                    lifetimes: None,
-                    path: Path {
-                        leading_colon: None,
-                        segments: Punctuated::from_iter([
-                            PathSegment {
-                                ident: Ident::new("Sized", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            }
-                        ])
-                    }
-                }
-            )
+            TypeParamBound::Trait(TraitBound {
+                paren_token: None,
+                modifier: TraitBoundModifier::None,
+                lifetimes: None,
+                path: Path {
+                    leading_colon: Some(Default::default()),
+                    segments: Punctuated::from_iter([
+                        PathSegment {
+                            ident: Ident::new("alohomora", Span::mixed_site()),
+                            arguments: PathArguments::None,
+                        },
+                        PathSegment {
+                            ident: Ident::new("policy", Span::mixed_site()),
+                            arguments: PathArguments::None,
+                        },
+                        PathSegment {
+                            ident: Ident::new("PolicyDyn", Span::mixed_site()),
+                            arguments: PathArguments::None,
+                        },
+                    ]),
+                },
+            }),
+            TypeParamBound::Trait(TraitBound {
+                paren_token: None,
+                modifier: TraitBoundModifier::Maybe(Default::default()),
+                lifetimes: None,
+                path: Path {
+                    leading_colon: None,
+                    segments: Punctuated::from_iter([PathSegment {
+                        ident: Ident::new("Sized", Span::mixed_site()),
+                        arguments: PathArguments::None,
+                    }]),
+                },
+            }),
         ]),
         eq_token: None,
         default: None,
@@ -147,68 +139,50 @@ fn sesame_type_where_clause(field_type: &Type) -> WherePredicate {
         lifetimes: None,
         bounded_ty: field_type.clone(),
         colon_token: Default::default(),
-        bounds: Punctuated::from_iter([
-            TypeParamBound::Trait(
-                TraitBound {
-                    paren_token: None,
-                    modifier: TraitBoundModifier::None,
-                    lifetimes: None,
-                    path: Path {
-                        leading_colon: Some(Default::default()),
-                        segments: Punctuated::from_iter([
-                            PathSegment {
-                                ident: Ident::new("alohomora", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("SesameType", Span::mixed_site()),
-                                arguments: PathArguments::AngleBracketed(
-                                    AngleBracketedGenericArguments {
-                                        colon2_token: Default::default(),
-                                        lt_token: Default::default(),
-                                        args: Punctuated::from_iter([
-                                            GenericArgument::Type(
-                                                Type::Path(
-                                                    TypePath {
-                                                        qself: None,
-                                                        path: Path {
-                                                            leading_colon: None,
-                                                            segments: Punctuated::from_iter([
-                                                                PathSegment {
-                                                                    ident: Ident::new("__TDyn", Span::mixed_site()),
-                                                                    arguments: PathArguments::None,
-                                                                }
-                                                            ])
-                                                        }
-                                                    }
-                                                )
-                                            ),
-                                            GenericArgument::Type(
-                                                Type::Path(
-                                                    TypePath {
-                                                        qself: None,
-                                                        path: Path {
-                                                            leading_colon: None,
-                                                            segments: Punctuated::from_iter([
-                                                                PathSegment {
-                                                                    ident: Ident::new("__PDyn", Span::mixed_site()),
-                                                                    arguments: PathArguments::None,
-                                                                }
-                                                            ])
-                                                        }
-                                                    }
-                                                )
-                                            )
-                                        ]),
-                                        gt_token: Default::default(),
-                                    }
-                                ),
-                            },
-                        ])
-                    }
-                }
-            )]
-        )
+        bounds: Punctuated::from_iter([TypeParamBound::Trait(TraitBound {
+            paren_token: None,
+            modifier: TraitBoundModifier::None,
+            lifetimes: None,
+            path: Path {
+                leading_colon: Some(Default::default()),
+                segments: Punctuated::from_iter([
+                    PathSegment {
+                        ident: Ident::new("alohomora", Span::mixed_site()),
+                        arguments: PathArguments::None,
+                    },
+                    PathSegment {
+                        ident: Ident::new("SesameType", Span::mixed_site()),
+                        arguments: PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                            colon2_token: Default::default(),
+                            lt_token: Default::default(),
+                            args: Punctuated::from_iter([
+                                GenericArgument::Type(Type::Path(TypePath {
+                                    qself: None,
+                                    path: Path {
+                                        leading_colon: None,
+                                        segments: Punctuated::from_iter([PathSegment {
+                                            ident: Ident::new("__TDyn", Span::mixed_site()),
+                                            arguments: PathArguments::None,
+                                        }]),
+                                    },
+                                })),
+                                GenericArgument::Type(Type::Path(TypePath {
+                                    qself: None,
+                                    path: Path {
+                                        leading_colon: None,
+                                        segments: Punctuated::from_iter([PathSegment {
+                                            ident: Ident::new("__PDyn", Span::mixed_site()),
+                                            arguments: PathArguments::None,
+                                        }]),
+                                    },
+                                })),
+                            ]),
+                            gt_token: Default::default(),
+                        }),
+                    },
+                ]),
+            },
+        })]),
     })
 }
 
@@ -221,50 +195,42 @@ fn verbatim_type_where_clause(field_type: &Type) -> WherePredicate {
             qself: None,
             path: Path {
                 leading_colon: None,
-                segments: Punctuated::from_iter([
-                    PathSegment {
-                        ident: Ident::new("__TDyn", Span::mixed_site()),
-                        arguments: PathArguments::None,
-                    }
-                ])
-            }
+                segments: Punctuated::from_iter([PathSegment {
+                    ident: Ident::new("__TDyn", Span::mixed_site()),
+                    arguments: PathArguments::None,
+                }]),
+            },
         }),
         colon_token: Default::default(),
-        bounds: Punctuated::from_iter([
-            TypeParamBound::Trait(
-                TraitBound {
-                    paren_token: None,
-                    modifier: TraitBoundModifier::None,
-                    lifetimes: None,
-                    path: Path {
-                        leading_colon: Some(Default::default()),
-                        segments: Punctuated::from_iter([
-                            PathSegment {
-                                ident: Ident::new("alohomora", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("sesame_type_dyns", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("SesameDynRelation", Span::mixed_site()),
-                                arguments: PathArguments::AngleBracketed(
-                                    AngleBracketedGenericArguments {
-                                        colon2_token: Default::default(),
-                                        lt_token: Default::default(),
-                                        args: Punctuated::from_iter([
-                                            GenericArgument::Type(field_type.clone()),
-                                        ]),
-                                        gt_token: Default::default(),
-                                    }
-                                ),
-                            },
-                        ])
-                    }
-                }
-            )]
-        )
+        bounds: Punctuated::from_iter([TypeParamBound::Trait(TraitBound {
+            paren_token: None,
+            modifier: TraitBoundModifier::None,
+            lifetimes: None,
+            path: Path {
+                leading_colon: Some(Default::default()),
+                segments: Punctuated::from_iter([
+                    PathSegment {
+                        ident: Ident::new("alohomora", Span::mixed_site()),
+                        arguments: PathArguments::None,
+                    },
+                    PathSegment {
+                        ident: Ident::new("sesame_type_dyns", Span::mixed_site()),
+                        arguments: PathArguments::None,
+                    },
+                    PathSegment {
+                        ident: Ident::new("SesameDynRelation", Span::mixed_site()),
+                        arguments: PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                            colon2_token: Default::default(),
+                            lt_token: Default::default(),
+                            args: Punctuated::from_iter([GenericArgument::Type(
+                                field_type.clone(),
+                            )]),
+                            gt_token: Default::default(),
+                        }),
+                    },
+                ]),
+            },
+        })]),
     })
 }
 
@@ -273,28 +239,24 @@ fn sesame_type_out_where_clause(field_type: &Type) -> WherePredicate {
         lifetimes: None,
         bounded_ty: field_type.clone(),
         colon_token: Default::default(),
-        bounds: Punctuated::from_iter([
-            TypeParamBound::Trait(
-                TraitBound {
-                    paren_token: None,
-                    modifier: TraitBoundModifier::None,
-                    lifetimes: None,
-                    path: Path {
-                        leading_colon: Some(Default::default()),
-                        segments: Punctuated::from_iter([
-                            PathSegment {
-                                ident: Ident::new("alohomora", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                            PathSegment {
-                                ident: Ident::new("SesameTypeOut", Span::mixed_site()),
-                                arguments: PathArguments::None,
-                            },
-                        ])
-                    }
-                }
-            )]
-        )
+        bounds: Punctuated::from_iter([TypeParamBound::Trait(TraitBound {
+            paren_token: None,
+            modifier: TraitBoundModifier::None,
+            lifetimes: None,
+            path: Path {
+                leading_colon: Some(Default::default()),
+                segments: Punctuated::from_iter([
+                    PathSegment {
+                        ident: Ident::new("alohomora", Span::mixed_site()),
+                        arguments: PathArguments::None,
+                    },
+                    PathSegment {
+                        ident: Ident::new("SesameTypeOut", Span::mixed_site()),
+                        arguments: PathArguments::None,
+                    },
+                ]),
+            },
+        })]),
     })
 }
 
@@ -312,17 +274,13 @@ fn derive_traits_for_output_type(attrs: &AlohomoraTypeArgs) -> Option<Attribute>
         meta: Meta::List(MetaList {
             path: Path {
                 leading_colon: None,
-                segments: Punctuated::from_iter(
-                    [
-                        PathSegment {
-                            ident: Ident::new("derive", Span::call_site()),
-                            arguments: PathArguments::None,
-                        }
-                    ]
-                ),
+                segments: Punctuated::from_iter([PathSegment {
+                    ident: Ident::new("derive", Span::call_site()),
+                    arguments: PathArguments::None,
+                }]),
             },
             delimiter: MacroDelimiter::Paren(Paren::default()),
-            tokens: quote!{ #(#trait_vec),* },
+            tokens: quote! { #(#trait_vec),* },
         }),
     })
 }
@@ -330,48 +288,59 @@ fn derive_traits_for_output_type(attrs: &AlohomoraTypeArgs) -> Option<Attribute>
 // Parse DeriveInput to a struct.
 pub fn parse_derive_input_struct(input: DeriveInput) -> Result<ItemStruct, Error> {
     match input.data {
-        Data::Enum(_) => Err((input.ident.span(), "derive(SesameType) only works on structs")),
-        Data::Union(_) => Err((input.ident.span(), "derive(SesameType) only works on structs")),
-        Data::Struct(data_struct) => Ok(
-            ItemStruct {
-                attrs: input.attrs,
-                vis: input.vis,
-                struct_token: data_struct.struct_token,
-                ident: input.ident,
-                generics: input.generics,
-                fields: data_struct.fields,
-                semi_token: data_struct.semi_token,
-            }
-        ),
+        Data::Enum(_) => Err((
+            input.ident.span(),
+            "derive(SesameType) only works on structs",
+        )),
+        Data::Union(_) => Err((
+            input.ident.span(),
+            "derive(SesameType) only works on structs",
+        )),
+        Data::Struct(data_struct) => Ok(ItemStruct {
+            attrs: input.attrs,
+            vis: input.vis,
+            struct_token: data_struct.struct_token,
+            ident: input.ident,
+            generics: input.generics,
+            fields: data_struct.fields,
+            semi_token: data_struct.semi_token,
+        }),
     }
 }
 
 // Construct the fields of the out type.
 fn construct_out_fields(input: &ItemStruct, attrs: &AlohomoraTypeArgs) -> Result<Fields, Error> {
     match &input.fields {
-        Fields::Named(fields) => Ok(
-            Fields::Named(FieldsNamed {
-                brace_token: Brace::default(),
-                named: fields.named.iter()
-                    .map( | field| {
-                        let mut field = field.clone();
-                        let ty = &field.ty;
-                        if !attrs.is_verbatim(&field.ident.as_ref().unwrap().to_string()) {
-                            field.ty = Type::Verbatim(quote! {
-                                <#ty as ::alohomora::SesameTypeOut>::Out
-                            });
-                        }
-                        field
-                    })
-                    .collect(),
-            })
-        ),
-        _ => Err((input.ident.span(), "derive(SesameType) only works on structs with named fields"))
+        Fields::Named(fields) => Ok(Fields::Named(FieldsNamed {
+            brace_token: Brace::default(),
+            named: fields
+                .named
+                .iter()
+                .map(|field| {
+                    let mut field = field.clone();
+                    let ty = &field.ty;
+                    if !attrs.is_verbatim(&field.ident.as_ref().unwrap().to_string()) {
+                        field.ty = Type::Verbatim(quote! {
+                            <#ty as ::alohomora::SesameTypeOut>::Out
+                        });
+                    }
+                    field
+                })
+                .collect(),
+        })),
+        _ => Err((
+            input.ident.span(),
+            "derive(SesameType) only works on structs with named fields",
+        )),
     }
 }
 
 // Construct the entirety of the output type.
-fn construct_out_type(input: &ItemStruct, attrs: &AlohomoraTypeArgs, alohomora_fields_types: &Vec<Type>) -> Result<ItemStruct, Error> {
+fn construct_out_type(
+    input: &ItemStruct,
+    attrs: &AlohomoraTypeArgs,
+    alohomora_fields_types: &Vec<Type>,
+) -> Result<ItemStruct, Error> {
     let mut result = input.clone();
     result.attrs = Vec::new();
     if let Some(attr) = derive_traits_for_output_type(attrs) {
@@ -382,21 +351,29 @@ fn construct_out_type(input: &ItemStruct, attrs: &AlohomoraTypeArgs, alohomora_f
         Some(name) => name.clone(),
     };
     result.fields = construct_out_fields(&input, attrs)?;
-    let mut where_clause_out = &mut result.generics.where_clause;
+    let where_clause_out = &mut result.generics.where_clause;
     if where_clause_out.is_none() {
         *where_clause_out = Some(WhereClause {
             where_token: Default::default(),
-            predicates: Punctuated::new()
+            predicates: Punctuated::new(),
         })
     };
     for field_type in alohomora_fields_types {
-        where_clause_out.as_mut().unwrap().predicates.push(sesame_type_out_where_clause(field_type));
+        where_clause_out
+            .as_mut()
+            .unwrap()
+            .predicates
+            .push(sesame_type_out_where_clause(field_type));
     }
     Ok(result)
 }
 
 // Add TDyn and PDyn impl generics and the bounds they require on the input type and fields.
-fn add_dyn_generics_and_bounds(input: &ItemStruct, alohomora_fields_types: &Vec<Type>, verbatim_fields_types: &Vec<Type>) -> ItemStruct {
+fn add_dyn_generics_and_bounds(
+    input: &ItemStruct,
+    alohomora_fields_types: &Vec<Type>,
+    verbatim_fields_types: &Vec<Type>,
+) -> ItemStruct {
     let mut input = input.clone();
 
     // Add trait bounds for SesameDyn and PolicyDyn.
@@ -407,15 +384,19 @@ fn add_dyn_generics_and_bounds(input: &ItemStruct, alohomora_fields_types: &Vec<
     if input.generics.where_clause.is_none() {
         input.generics.where_clause = Some(WhereClause {
             where_token: Default::default(),
-            predicates: Punctuated::new()
+            predicates: Punctuated::new(),
         })
     }
     let where_clause = input.generics.where_clause.as_mut().unwrap();
     for field_type in alohomora_fields_types {
-        where_clause.predicates.push(sesame_type_where_clause(field_type));
+        where_clause
+            .predicates
+            .push(sesame_type_where_clause(field_type));
     }
     for field_type in verbatim_fields_types {
-        where_clause.predicates.push(verbatim_type_where_clause(field_type));
+        where_clause
+            .predicates
+            .push(verbatim_type_where_clause(field_type));
     }
 
     input
@@ -429,12 +410,16 @@ pub fn derive_sesame_type_impl(input: DeriveInput) -> Result<TokenStream, Error>
     let input = parse_derive_input_struct(input)?;
 
     // Find all fields.
-    let fields: Vec<_> = input.fields.iter()
-        .map(|field| (
-            field.ident.as_ref().unwrap().clone(),
-            field.ident.as_ref().unwrap().to_string(),
-            field.ty.clone(),
-        ))
+    let fields: Vec<_> = input
+        .fields
+        .iter()
+        .map(|field| {
+            (
+                field.ident.as_ref().unwrap().clone(),
+                field.ident.as_ref().unwrap().to_string(),
+                field.ty.clone(),
+            )
+        })
         .collect();
 
     // Filter into those that are AlohomoraTypes themselves, and those who are kept verbatim.
@@ -480,13 +465,14 @@ pub fn derive_sesame_type_impl(input: DeriveInput) -> Result<TokenStream, Error>
     let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
 
     // The impl block generics include newly added generics and bounds for TDyn and PDyn.
-    let modified_input = add_dyn_generics_and_bounds(&input, &alohomora_fields_types, &verbatim_fields_types);
+    let modified_input =
+        add_dyn_generics_and_bounds(&input, &alohomora_fields_types, &verbatim_fields_types);
     let (impl_generics_dyns, _, where_clause_dyns) = modified_input.generics.split_for_impl();
 
     // Construct the output struct.
     let out = construct_out_type(&input, &attrs, &alohomora_fields_types)?;
     let input_ident = &input.ident;
-    let out_ident = &out.ident;// Add where clauses to the out impl block on the form of ($field: SesameTypeOut)
+    let out_ident = &out.ident; // Add where clauses to the out impl block on the form of ($field: SesameTypeOut)
     let (_, _, where_clause_out) = out.generics.split_for_impl();
 
     // Generate implementation.

--- a/alohomora_derive/src/form.rs
+++ b/alohomora_derive/src/form.rs
@@ -6,7 +6,10 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
-use syn::{Data, DataStruct, DeriveInput, Field, Fields, GenericParam, Generics, Lifetime, LifetimeParam, Token, Type};
+use syn::{
+    Data, DataStruct, DeriveInput, Field, Fields, GenericParam, Generics, Lifetime, LifetimeParam,
+    Token, Type,
+};
 
 pub fn context_generics(mut generics: Generics) -> Generics {
     let mut r_bound = Punctuated::new();
@@ -68,17 +71,17 @@ pub fn generate_context(
 
     // Getters for every field context.
     let getters = fields.iter().zip(types.iter()).map(|(field, ty)| {
-    let ident = field.ident.as_ref().unwrap();
-    let function_name = Ident::new(&format!("get_{}_ctx", ident), ident.span());
-    quote! {
-      fn #function_name (&mut self) -> &mut #ty::BBoxContext {
-        if let ::std::option::Option::None = self.#ident {
-          self.#ident = ::std::option::Option::Some(#ty::bbox_init(self.__opts));
+        let ident = field.ident.as_ref().unwrap();
+        let function_name = Ident::new(&format!("get_{}_ctx", ident), ident.span());
+        quote! {
+          fn #function_name (&mut self) -> &mut #ty::BBoxContext {
+            if let ::std::option::Option::None = self.#ident {
+              self.#ident = ::std::option::Option::Some(#ty::bbox_init(self.__opts));
+            }
+            self.#ident.as_mut().unwrap()
+          }
         }
-        self.#ident.as_mut().unwrap()
-      }
-    }
-  });
+    });
 
     // Generated context struct must declare the same generics.
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();

--- a/alohomora_derive/src/json.rs
+++ b/alohomora_derive/src/json.rs
@@ -2,10 +2,10 @@ extern crate proc_macro2;
 extern crate quote;
 extern crate syn;
 
-use proc_macro2::{Span, Ident, TokenStream};
+use attribute_derive::FromAttr;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{Data, DeriveInput, ItemStruct};
-use attribute_derive::FromAttr;
 
 pub type Error = (Span, &'static str);
 
@@ -28,19 +28,23 @@ impl ResponseBBoxJsonArgs {
 // Parse DeriveInput to a struct.
 fn parse_derive_input_struct(input: DeriveInput) -> Result<ItemStruct, Error> {
     match input.data {
-        Data::Enum(_) => Err((input.ident.span(), "derive(FromBBoxJson) only works on structs")),
-        Data::Union(_) => Err((input.ident.span(), "derive(FromBBoxJson) only works on structs")),
-        Data::Struct(data_struct) => Ok(
-            ItemStruct {
-                attrs: input.attrs,
-                vis: input.vis,
-                struct_token: data_struct.struct_token,
-                ident: input.ident,
-                generics: input.generics,
-                fields: data_struct.fields,
-                semi_token: data_struct.semi_token,
-            }
-        ),
+        Data::Enum(_) => Err((
+            input.ident.span(),
+            "derive(FromBBoxJson) only works on structs",
+        )),
+        Data::Union(_) => Err((
+            input.ident.span(),
+            "derive(FromBBoxJson) only works on structs",
+        )),
+        Data::Struct(data_struct) => Ok(ItemStruct {
+            attrs: input.attrs,
+            vis: input.vis,
+            struct_token: data_struct.struct_token,
+            ident: input.ident,
+            generics: input.generics,
+            fields: data_struct.fields,
+            semi_token: data_struct.semi_token,
+        }),
     }
 }
 
@@ -53,7 +57,11 @@ pub fn request_impl(input: DeriveInput) -> Result<TokenStream, Error> {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     // List all fields.
-    let fields: Vec<_> = input.fields.iter().map(|field| field.ident.as_ref().unwrap()).collect();
+    let fields: Vec<_> = input
+        .fields
+        .iter()
+        .map(|field| field.ident.as_ref().unwrap())
+        .collect();
     let fields_strings: Vec<_> = fields.iter().map(|field| field.to_string()).collect();
 
     // Generate implementation.
@@ -83,12 +91,22 @@ pub fn response_impl(input: DeriveInput) -> Result<TokenStream, Error> {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     // List all fields.
-    let all_fields: Vec<_> = input.fields.iter().map(|field| field.ident.as_ref().unwrap()).collect();
+    let all_fields: Vec<_> = input
+        .fields
+        .iter()
+        .map(|field| field.ident.as_ref().unwrap())
+        .collect();
 
-    let fields: Vec<_> = all_fields.iter().filter(|field| !attrs.contains(field)).collect();
+    let fields: Vec<_> = all_fields
+        .iter()
+        .filter(|field| !attrs.contains(field))
+        .collect();
     let fields_strings: Vec<_> = fields.iter().map(|field| field.to_string()).collect();
 
-    let as_is: Vec<_> = all_fields.iter().filter(|field| attrs.contains(field)).collect();
+    let as_is: Vec<_> = all_fields
+        .iter()
+        .filter(|field| attrs.contains(field))
+        .collect();
     let as_is_strings: Vec<_> = as_is.iter().map(|field| field.to_string()).collect();
 
     // Generate implementation.

--- a/alohomora_derive/src/lib.rs
+++ b/alohomora_derive/src/lib.rs
@@ -8,14 +8,14 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{parse_macro_input, DeriveInput, Expr, ItemFn, ItemStruct};
 
+mod alohomora_type;
 mod form;
+mod json;
+mod no_fold_in;
 mod policy;
 mod render;
 mod route;
-mod alohomora_type;
 mod sandbox;
-mod json;
-mod no_fold_in;
 
 #[proc_macro_derive(BBoxRender)]
 pub fn derive_boxed_serialize(input: TokenStream) -> TokenStream {
@@ -108,7 +108,6 @@ pub fn derive_sandboxable(input: TokenStream) -> TokenStream {
         Err((span, err)) => quote_spanned!(span => compile_error!(#err)).into(),
     }
 }
-
 
 #[proc_macro_derive(RequestBBoxJson)]
 pub fn derive_request_bbox_json(input: TokenStream) -> TokenStream {

--- a/alohomora_derive/src/lib.rs
+++ b/alohomora_derive/src/lib.rs
@@ -81,10 +81,10 @@ pub fn routes(input: TokenStream) -> TokenStream {
     result.into()
 }
 
-#[proc_macro_derive(SesameTypeDyn, attributes(alohomora_out_type))]
-pub fn derive_alohomora_type(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(SesameType, attributes(alohomora_out_type))]
+pub fn derive_sesame_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    match alohomora_type::derive_alohomora_type_impl(input) {
+    match alohomora_type::derive_sesame_type_impl(input) {
         Ok(tokens) => tokens.into(),
         Err((span, err)) => quote_spanned!(span => compile_error!(#err)).into(),
     }
@@ -128,7 +128,7 @@ pub fn dervie_response_bbox_json(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(NoFoldIn, attributes(alohomora_out_type))]
+#[proc_macro_derive(NoFoldIn)]
 pub fn derive_no_fold_in(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match no_fold_in::derive_no_fold_in_impl(input) {

--- a/alohomora_derive/src/no_fold_in.rs
+++ b/alohomora_derive/src/no_fold_in.rs
@@ -13,9 +13,7 @@ pub fn parse_input_struct_name(input: DeriveInput) -> Result<Ident, Error> {
     match input.data {
         Data::Enum(_) => Err((input.ident.span(), "derive(NoFoldIn) only works on structs")),
         Data::Union(_) => Err((input.ident.span(), "derive(NoFoldIn) only works on structs")),
-        Data::Struct(_) => Ok(
-            input.ident
-        ),
+        Data::Struct(_) => Ok(input.ident),
     }
 }
 

--- a/alohomora_derive/src/route/parse.rs
+++ b/alohomora_derive/src/route/parse.rs
@@ -193,7 +193,6 @@ impl Parse for DataArg {
     }
 }
 
-
 // with_data = "<data>".
 struct WithDataArg {
     pub parameter: String,

--- a/alohomora_derive/src/route/route.rs
+++ b/alohomora_derive/src/route/route.rs
@@ -37,10 +37,10 @@ type PathParam = (Parameter, usize);
 
 // Types of parameters.
 enum ParamClass {
-    Data,      // Use FromBBoxData.
-    Query,     // Use FromBBoxForm.
-    Path,      // Use FromBBoxParam.
-    DataGuard, // Use FromBBoxRequest.
+    Data,              // Use FromBBoxData.
+    Query,             // Use FromBBoxForm.
+    Path,              // Use FromBBoxParam.
+    DataGuard,         // Use FromBBoxRequest.
     DataGuardWithData, // Use FromBBoxRequestAndData
 }
 
@@ -98,8 +98,8 @@ impl RouteAttribute {
             match &self.data {
                 Some(p) if p == name => Some(ParamClass::Data),
                 _ => match &self.with_data {
-                  Some(p) if p == name => Some(ParamClass::DataGuardWithData),
-                  _ => None,
+                    Some(p) if p == name => Some(ParamClass::DataGuardWithData),
+                    _ => None,
                 },
             }
         }
@@ -208,7 +208,7 @@ pub fn route_impl<T: RouteType>(args: RouteArgs<T>, input: ItemFn) -> TokenStrea
     });
 
     // Do post data.
-    let mut with_data = quote!{};
+    let mut with_data = quote! {};
     let post_data = match args.data.as_ref() {
         None => quote! {},
         Some(data) => {

--- a/alohomora_derive/tests/alohomora_type.rs
+++ b/alohomora_derive/tests/alohomora_type.rs
@@ -1,29 +1,36 @@
-use alohomora::policy::{AnyPolicy, NoPolicy};
-use alohomora::bbox::BBox;
-use alohomora::AlohomoraType;
 use std::collections::HashMap;
+
+use alohomora::SesameType;
+use alohomora::bbox::BBox;
 use alohomora::fold::fold;
-use alohomora_derive::AlohomoraType;
+use alohomora::policy::{AnyPolicy, AnyPolicyClone, AnyPolicyCloneDyn, NoPolicy};
+use serde::Serialize;
+use alohomora_derive::SesameType;
 
 // The struct is its own out type.
-#[derive(AlohomoraType, Clone, PartialEq, Debug)]
+#[derive(SesameType, Clone, PartialEq, Debug, Serialize)]
 #[alohomora_out_type(to_derive = [PartialEq, Debug])]
 pub struct NoBoxes {
     pub f1: u64,
     pub f2: String,
 }
+
 #[test]
 fn test_derived_no_boxes() {
     let input = NoBoxes { f1: 10, f2: String::from("hello") };
-    let folded: BBox<_, AnyPolicy> = fold(input).unwrap();
+    let folded: BBox<_, AnyPolicy> = fold(input.clone()).unwrap();
     let folded: BBox<_, NoPolicy> = folded.specialize_policy().unwrap();
     let folded = folded.discard_box();
     assert_eq!(folded.f1, 10);
     assert_eq!(folded.f2, String::from("hello"));
+
+    let folded: BBox<_, AnyPolicy<dyn AnyPolicyCloneDyn>> = fold::<dyn AnyPolicyCloneDyn, NoBoxes>(input.clone()).unwrap();
+    let folded: BBox<_, NoPolicy> = folded.specialize_policy().unwrap();
 }
 
+/*
 // The struct contains a mix.
-#[derive(AlohomoraType, Clone, PartialEq, Debug)]
+#[derive(SesameTypeDyn, Clone, PartialEq, Debug)]
 #[alohomora_out_type(to_derive = [PartialEq, Debug])]
 pub struct MixedBoxes {
     pub f1: BBox<u64, NoPolicy>,
@@ -41,7 +48,7 @@ fn test_mixed_boxes() {
         f4: String::from("bye"),
     };
 
-    type MixedBoxesOut = <MixedBoxes as AlohomoraType>::Out;
+    type MixedBoxesOut = <MixedBoxes as SesameTypeDyn>::Out;
     let expected = MixedBoxesOut {
         f1: 10,
         f2: String::from("hello"),
@@ -49,14 +56,14 @@ fn test_mixed_boxes() {
         f4: String::from("bye"),
     };
 
-    let folded: BBox<<MixedBoxes as AlohomoraType>::Out, AnyPolicy> = fold(input).unwrap();
-    let folded: BBox<<MixedBoxes as AlohomoraType>::Out, NoPolicy> = folded.specialize_policy().unwrap();
+    let folded: BBox<<MixedBoxes as SesameTypeDyn>::Out, AnyPolicyCC> = fold(input).unwrap();
+    let folded: BBox<<MixedBoxes as SesameTypeDyn>::Out, NoPolicy> = folded.specialize_policy().unwrap();
     assert_eq!(folded.discard_box(), expected);
 }
 
 // Test specifying the output name.
 // Test having containers of nested types.
-#[derive(AlohomoraType, Clone, PartialEq, Debug)]
+#[derive(SesameTypeDyn, Clone, PartialEq, Debug)]
 #[alohomora_out_type(name = NestedOut, to_derive = [PartialEq, Debug])]
 pub struct NestedBoxes {
     pub f1: NoBoxes,
@@ -117,7 +124,7 @@ fn test_nested_boxes() {
         ]),
     };
 
-    let folded: BBox<NestedOut, AnyPolicy> = fold(input).unwrap();
+    let folded: BBox<NestedOut, AnyPolicyCC> = fold(input).unwrap();
     let folded: BBox<NestedOut, NoPolicy>  = folded.specialize_policy().unwrap();
     let folded: NestedOut = folded.discard_box();
 
@@ -170,7 +177,7 @@ fn test_nested_boxes() {
 #[derive(PartialEq, Debug, Clone)]
 pub struct VerbatimType(pub u32, pub String);
 
-#[derive(AlohomoraType, Clone, PartialEq, Debug)]
+#[derive(SesameTypeDyn, Clone, PartialEq, Debug)]
 #[alohomora_out_type(to_derive = [PartialEq, Debug])]
 #[alohomora_out_type(verbatim = [f3])]
 pub struct VerbatimBox {
@@ -187,7 +194,7 @@ fn test_derived_verbatim() {
         f3: VerbatimType(20, String::from("bye")),
     };
 
-    let folded: BBox<_, AnyPolicy> = fold(input).unwrap();
+    let folded: BBox<_, AnyPolicyCC> = fold(input).unwrap();
     let folded: BBox<_, NoPolicy> = folded.specialize_policy().unwrap();
     let folded = folded.discard_box();
 
@@ -198,7 +205,7 @@ fn test_derived_verbatim() {
 
 
 // Struct with only verbatim items.
-#[derive(AlohomoraType, Clone, PartialEq, Debug)]
+#[derive(SesameTypeDyn, Clone, PartialEq, Debug)]
 #[alohomora_out_type(to_derive = [PartialEq, Debug])]
 #[alohomora_out_type(verbatim = [f1, f2])]
 pub struct OnlyVerbatimBox {
@@ -213,10 +220,11 @@ fn test_derived_only_verbatim() {
         f2: VerbatimType(20, String::from("bye")),
     };
 
-    let folded: BBox<_, AnyPolicy> = fold(input).unwrap();
+    let folded: BBox<_, AnyPolicyCC> = fold(input).unwrap();
     let folded: BBox<_, NoPolicy> = folded.specialize_policy().unwrap();
     let folded = folded.discard_box();
 
     assert_eq!(folded.f1, 10);
     assert_eq!(folded.f2, VerbatimType(20, String::from("bye")));
 }
+*/

--- a/alohomora_derive/tests/alohomora_type.rs
+++ b/alohomora_derive/tests/alohomora_type.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use alohomora::{SesameType, SesameTypeOut};
 use alohomora::bbox::BBox;
 use alohomora::context::UnprotectedContext;
 use alohomora::fold::fold;
 use alohomora::policy::{AnyPolicy, AnyPolicyClone, NoPolicy, Policy, Reason, SimplePolicy};
 use alohomora::testing::TestPolicy;
-use serde::Serialize;
+use alohomora::{SesameTypeOut};
 use alohomora_derive::SesameType;
+use serde::Serialize;
 
 // The struct is its own out type.
 #[derive(SesameType, Clone, PartialEq, Debug, Serialize)]
@@ -19,7 +19,10 @@ pub struct NoBoxes {
 
 #[test]
 fn test_derived_no_boxes() {
-    let input = NoBoxes { f1: 10, f2: String::from("hello") };
+    let input = NoBoxes {
+        f1: 10,
+        f2: String::from("hello"),
+    };
     let folded: BBox<_, AnyPolicy> = fold(input.clone()).unwrap();
     let folded: BBox<_, NoPolicy> = folded.specialize_policy().unwrap();
     let folded = folded.discard_box();
@@ -58,7 +61,8 @@ fn test_mixed_boxes() {
     };
 
     let folded: BBox<<MixedBoxes as SesameTypeOut>::Out, AnyPolicyClone> = fold(input).unwrap();
-    let folded: BBox<<MixedBoxes as SesameTypeOut>::Out, NoPolicy> = folded.specialize_policy().unwrap();
+    let folded: BBox<<MixedBoxes as SesameTypeOut>::Out, NoPolicy> =
+        folded.specialize_policy().unwrap();
     assert_eq!(folded.discard_box(), expected);
 }
 
@@ -76,11 +80,10 @@ pub struct NestedBoxes {
 impl NestedOut {
     pub fn sum(self) -> u64 {
         let v_sum = self.f2.iter().fold(0, |acc, v| acc + v.f1 + v.f3);
-        let m_sum =  self.f3.iter().fold(0, |acc, (_k, v)| acc + v.f1 + v.f3);
+        let m_sum = self.f3.iter().fold(0, |acc, (_k, v)| acc + v.f1 + v.f3);
         self.f1.f1 + v_sum + m_sum
     }
 }
-
 
 #[test]
 fn test_nested_boxes() {
@@ -110,69 +113,82 @@ fn test_nested_boxes() {
             },
         ],
         f3: HashMap::from([
-            (String::from("k0"), MixedBoxes {
-                f1: BBox::new(7, NoPolicy {}),
-                f2: BBox::new(String::from("k0.f2"), NoPolicy {}),
-                f3: 8,
-                f4: String::from("k0.f4"),
-            }),
-            (String::from("k1"), MixedBoxes {
-                f1: BBox::new(9, NoPolicy {}),
-                f2: BBox::new(String::from("k1.f2"), NoPolicy {}),
-                f3: 10,
-                f4: String::from("k1.f4"),
-            })
+            (
+                String::from("k0"),
+                MixedBoxes {
+                    f1: BBox::new(7, NoPolicy {}),
+                    f2: BBox::new(String::from("k0.f2"), NoPolicy {}),
+                    f3: 8,
+                    f4: String::from("k0.f4"),
+                },
+            ),
+            (
+                String::from("k1"),
+                MixedBoxes {
+                    f1: BBox::new(9, NoPolicy {}),
+                    f2: BBox::new(String::from("k1.f2"), NoPolicy {}),
+                    f3: 10,
+                    f4: String::from("k1.f4"),
+                },
+            ),
         ]),
     };
 
     let folded: BBox<NestedOut, AnyPolicyClone> = fold(input).unwrap();
-    let folded: BBox<NestedOut, NoPolicy>  = folded.specialize_policy().unwrap();
+    let folded: BBox<NestedOut, NoPolicy> = folded.specialize_policy().unwrap();
     let folded: NestedOut = folded.discard_box();
 
-
-    assert_eq!(folded, NestedOut {
-        f1: NoBoxesOut {
-            f1: 10,
-            f2: String::from("hello"),
-        },
-        f2: vec![
-            MixedBoxesOut {
-                f1: 1,
-                f2: String::from("v0.f2"),
-                f3: 2,
-                f4: String::from("v0.f4"),
+    assert_eq!(
+        folded,
+        NestedOut {
+            f1: NoBoxesOut {
+                f1: 10,
+                f2: String::from("hello"),
             },
-            MixedBoxesOut {
-                f1: 3,
-                f2: String::from("v1.f2"),
-                f3: 4,
-                f4: String::from("v1.f4"),
-            },
-            MixedBoxesOut {
-                f1: 5,
-                f2: String::from("v2.f2"),
-                f3: 6,
-                f4: String::from("v2.f4"),
-            },
-        ],
-        f3: HashMap::from([
-            (String::from("k0"), MixedBoxesOut {
-                f1: 7,
-                f2: String::from("k0.f2"),
-                f3: 8,
-                f4: String::from("k0.f4"),
-            }),
-            (String::from("k1"), MixedBoxesOut {
-                f1: 9,
-                f2: String::from("k1.f2"),
-                f3: 10,
-                f4: String::from("k1.f4"),
-            })
-        ]),
-    });
+            f2: vec![
+                MixedBoxesOut {
+                    f1: 1,
+                    f2: String::from("v0.f2"),
+                    f3: 2,
+                    f4: String::from("v0.f4"),
+                },
+                MixedBoxesOut {
+                    f1: 3,
+                    f2: String::from("v1.f2"),
+                    f3: 4,
+                    f4: String::from("v1.f4"),
+                },
+                MixedBoxesOut {
+                    f1: 5,
+                    f2: String::from("v2.f2"),
+                    f3: 6,
+                    f4: String::from("v2.f4"),
+                },
+            ],
+            f3: HashMap::from([
+                (
+                    String::from("k0"),
+                    MixedBoxesOut {
+                        f1: 7,
+                        f2: String::from("k0.f2"),
+                        f3: 8,
+                        f4: String::from("k0.f4"),
+                    }
+                ),
+                (
+                    String::from("k1"),
+                    MixedBoxesOut {
+                        f1: 9,
+                        f2: String::from("k1.f2"),
+                        f3: 10,
+                        f4: String::from("k1.f4"),
+                    }
+                )
+            ]),
+        }
+    );
     assert_eq!(folded.sum(), 65);
 }
-
 
 // Struct with verbatim items.
 #[derive(PartialEq, Debug, Clone)]
@@ -228,7 +244,6 @@ fn test_derived_only_verbatim() {
     assert_eq!(folded.f2, VerbatimType(20, String::from("bye")));
 }
 
-
 // Struct with generic item.
 #[derive(SesameType, Clone)]
 pub struct GenericBox<T, P: Policy> {
@@ -239,9 +254,13 @@ pub struct GenericBox<T, P: Policy> {
 // A policy type that is not cloneable.
 struct NotClone {}
 impl SimplePolicy for NotClone {
-    fn simple_name(&self) -> String { String::from("") }
-    fn simple_check(&self, context: &UnprotectedContext, reason: Reason<'_>) -> bool { true }
-    fn simple_join_direct(&mut self, other: &mut Self) {}
+    fn simple_name(&self) -> String {
+        String::from("")
+    }
+    fn simple_check(&self, _context: &UnprotectedContext, _reason: Reason<'_>) -> bool {
+        true
+    }
+    fn simple_join_direct(&mut self, _other: &mut Self) {}
 }
 
 #[test]

--- a/alohomora_derive/tests/no_fold_in.rs
+++ b/alohomora_derive/tests/no_fold_in.rs
@@ -3,11 +3,10 @@
 #[macro_use]
 extern crate static_assertions;
 
-use alohomora::policy::{SimplePolicy};
-use alohomora_derive::NoFoldIn;
 use alohomora::context::UnprotectedContext;
-use alohomora::policy::Reason; 
-
+use alohomora::policy::Reason;
+use alohomora::policy::SimplePolicy;
+use alohomora_derive::NoFoldIn;
 
 #[derive(NoFoldIn, Clone, Debug, PartialEq, Eq)]
 struct NoFoldPolicy {
@@ -26,7 +25,7 @@ impl SimplePolicy for NoFoldPolicy {
     }
 }
 
-// This correctly fails to compile. 
+// This correctly fails to compile.
 #[test]
 fn test_fold_in_denied() {
     use alohomora::fold_in::FoldInAllowed;

--- a/alohomora_derive/tests/no_fold_in.rs
+++ b/alohomora_derive/tests/no_fold_in.rs
@@ -3,9 +3,8 @@
 #[macro_use]
 extern crate static_assertions;
 
-use alohomora::policy::{Policy, AnyPolicy};
+use alohomora::policy::{SimplePolicy};
 use alohomora_derive::NoFoldIn;
-use alohomora::bbox::BBox;
 use alohomora::context::UnprotectedContext;
 use alohomora::policy::Reason; 
 
@@ -15,18 +14,15 @@ struct NoFoldPolicy {
     pub attr: String,
 }
 
-impl Policy for NoFoldPolicy {
-    fn name(&self) -> String {
+impl SimplePolicy for NoFoldPolicy {
+    fn simple_name(&self) -> String {
         String::from("NoFoldInPolicy")
     }
-    fn check(&self, _context: &UnprotectedContext, _reason: Reason) -> bool {
+    fn simple_check(&self, _context: &UnprotectedContext, _reason: Reason) -> bool {
         true
     }
-    fn join(&self, _other: AnyPolicy) -> Result<AnyPolicy, ()> {
-        Ok(AnyPolicy::new(self.clone()))
-    }
-    fn join_logic(&self, _other: Self) -> Result<Self, ()> {
-        Ok(NoFoldPolicy { attr: String::from("") })
+    fn simple_join_direct(&mut self, other: &mut Self) {
+        self.attr = format!("{}+{}", self.attr, other.attr);
     }
 }
 

--- a/alohomora_derive/tests/render.rs
+++ b/alohomora_derive/tests/render.rs
@@ -1,8 +1,8 @@
 use alohomora::context::Context;
-use alohomora::policy::{Policy, RefPolicy, NoPolicy};
+use alohomora::pcr::{PrivacyCriticalRegion, Signature};
+use alohomora::policy::{NoPolicy, Policy, RefPolicy};
 use alohomora_derive::BBoxRender;
 use erased_serde::Serialize;
-use alohomora::pcr::{PrivacyCriticalRegion, Signature};
 
 type RefBBox<'a> = alohomora::bbox::BBox<&'a dyn Serialize, RefPolicy<'a, dyn Policy + 'a>>;
 
@@ -47,9 +47,12 @@ fn bbox_to_string<'a>(bbox: &'a RefBBox<'_>) -> Result<String, ()> {
         context,
         PrivacyCriticalRegion::new(
             |t: &&'a dyn Serialize, _| *t,
-            Signature { username: "", signature: "" },
+            Signature {
+                username: "",
+                signature: "",
+            },
         ),
-        ()
+        (),
     );
     serialize_to_string(result.unwrap())
 }
@@ -103,11 +106,16 @@ fn simple_render_struct() {
             matches!(t4.get("v"), Option::Some(Renderable::Array(_)));
             if let Renderable::Array(v) = t4.get("v").unwrap() {
                 assert_eq!(v.len(), 3);
-                assert!(matches!(&v[0], Renderable::BBox(a) if bbox_to_string(a) == Ok(String::from("100"))));
-                assert!(matches!(&v[1], Renderable::BBox(a) if bbox_to_string(a) == Ok(String::from("110"))));
-                assert!(matches!(&v[2], Renderable::BBox(a) if bbox_to_string(a) == Ok(String::from("200"))));
+                assert!(
+                    matches!(&v[0], Renderable::BBox(a) if bbox_to_string(a) == Ok(String::from("100")))
+                );
+                assert!(
+                    matches!(&v[1], Renderable::BBox(a) if bbox_to_string(a) == Ok(String::from("110")))
+                );
+                assert!(
+                    matches!(&v[2], Renderable::BBox(a) if bbox_to_string(a) == Ok(String::from("200")))
+                );
             }
         }
     }
-
 }

--- a/alohomora_derive/tests/schema_policy.rs
+++ b/alohomora_derive/tests/schema_policy.rs
@@ -1,8 +1,8 @@
 use alohomora::policy::{NoPolicy, Policy, Reason, SchemaPolicy, SimplePolicy, Specializable};
 use alohomora_derive::schema_policy;
 
-use mysql::Value;
 use alohomora::context::UnprotectedContext;
+use mysql::Value;
 
 #[schema_policy(table = "my_table", column = 3)]
 #[derive(Clone)]
@@ -14,7 +14,7 @@ impl SimplePolicy for SamplePolicy {
     fn simple_check(&self, _: &UnprotectedContext, _: Reason) -> bool {
         true
     }
-    fn simple_join_direct(&mut self, other: &mut Self) {}
+    fn simple_join_direct(&mut self, _other: &mut Self) {}
 }
 impl SchemaPolicy for SamplePolicy {
     fn from_row(_table: &str, _row: &Vec<Value>) -> Self {


### PR DESCRIPTION
* Derive macro implements SesameType generically over all possible SesameDyns and PolicyDyns.
* Derive macro poses correct bounds on the dyns and generics
* Derive macro supports structs with their own generics
* Updated SesameType so that Out type is invariant over which SesameDyns and PolicyDyns are instantiated
* Updated derive tests