### PR TITLE
perf(mysql): resolve schema policies once per query instead of per cell

### DIFF
--- a/sesame/mysql/src/connection.rs
+++ b/sesame/mysql/src/connection.rs
@@ -79,7 +79,7 @@ impl SesameConn {
         query: T,
     ) -> PConResult<PConQueryResult<'_, '_, '_, mysql::Text>> {
         let result = self.conn.query_iter(query)?;
-        Ok(PConQueryResult { result })
+        Ok(PConQueryResult::new(result))
     }
 
     // Parameterized query and return iterator to result.
@@ -103,7 +103,7 @@ impl SesameConn {
             Reason::DB(&stmt_str, param_values.iter().collect()),
         )?;
         let result = self.conn.exec_iter(statement, params)?;
-        Ok(PConQueryResult { result })
+        Ok(PConQueryResult::new(result))
     }
 
     // Chained prep and exec function

--- a/sesame/mysql/src/policy.rs
+++ b/sesame/mysql/src/policy.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use sesame::policy::{AnyPolicy, AnyPolicyable, NoPolicy, Policy, PolicyAnd, PolicyOr};
 
@@ -30,9 +30,11 @@ impl<P1: SchemaPolicy, P2: SchemaPolicy> SchemaPolicy for PolicyOr<P1, P2> {
     }
 }
 
-// Global static singleton.
+// Global static singleton. Factories are individually reference
+// counted so a query can snapshot the ones its columns need once and
+// share them across all of its rows without holding the lock.
 type SchemaPolicyFactory = dyn (Fn(&Vec<mysql::Value>) -> AnyPolicy) + Send + Sync;
-type SchemaPolicyMap = HashMap<(String, usize), Vec<Box<SchemaPolicyFactory>>>;
+type SchemaPolicyMap = HashMap<(String, usize), Vec<Arc<SchemaPolicyFactory>>>;
 lazy_static! {
     static ref SCHEMA_POLICIES: RwLock<SchemaPolicyMap> = RwLock::new(SchemaPolicyMap::new());
 }
@@ -46,6 +48,46 @@ fn fold_policies<I: Iterator<Item = AnyPolicy>>(mut policies: I) -> AnyPolicy {
                 policy = AnyPolicy::new(PolicyAnd::new(policy, next));
             }
             policy
+        }
+    }
+}
+
+// The registered factories for every column of a result set, resolved
+// once per query and shared by all of its rows. Indexed by column
+// position; columns with no registered policy hold an empty Vec.
+pub(crate) struct ColumnPolicies {
+    factories: Vec<Vec<Arc<SchemaPolicyFactory>>>,
+}
+
+impl ColumnPolicies {
+    // Resolve the factories for a result set's columns. One lock
+    // acquisition and one map lookup per column, instead of one per
+    // cell. Registration runs in `ctor` functions before main (the
+    // #[schema_policy] macro is the only sanctioned caller of
+    // add_schema_policy), so the registry cannot change between this
+    // snapshot and the rows it serves.
+    pub(crate) fn resolve(columns: &[mysql::Column]) -> Arc<Self> {
+        let map = SCHEMA_POLICIES.read().unwrap();
+        let factories = columns
+            .iter()
+            .enumerate()
+            .map(|(idx, col)| {
+                map.get(&(col.table_str().into_owned(), idx))
+                    .cloned()
+                    .unwrap_or_default()
+            })
+            .collect();
+        Arc::new(ColumnPolicies { factories })
+    }
+
+    // Build the policy for one cell, exactly as get_schema_policies
+    // does: the fold of every registered factory applied to the row,
+    // or NoPolicy when none are registered.
+    pub(crate) fn for_cell(&self, column: usize, row: &Vec<mysql::Value>) -> AnyPolicy {
+        match self.factories.get(column) {
+            None => AnyPolicy::new(NoPolicy {}),
+            Some(factories) if factories.is_empty() => AnyPolicy::new(NoPolicy {}),
+            Some(factories) => fold_policies(factories.iter().map(|factory| factory(row))),
         }
     }
 }
@@ -71,7 +113,7 @@ pub fn add_schema_policy<T: SchemaPolicy + AnyPolicyable>(table_name: String, co
     let mut map = SCHEMA_POLICIES.write().unwrap();
     map.entry((table_name.clone(), column))
         .or_default()
-        .push(Box::new(move |row: &Vec<mysql::Value>| {
+        .push(Arc::new(move |row: &Vec<mysql::Value>| {
             AnyPolicy::new(T::from_row(&table_name, row))
         }));
 }

--- a/sesame/mysql/src/result.rs
+++ b/sesame/mysql/src/result.rs
@@ -1,13 +1,23 @@
+use std::sync::Arc;
+
+use crate::policy::ColumnPolicies;
 use crate::PConRow;
 
 // mysql imports.
 pub use mysql::SetColumns as PConSetColumns;
 
-// Our result wrapper.
+// Our result wrapper. Resolves the schema-policy factories for its
+// column set once at construction; every row shares that snapshot, so
+// per-cell policy attachment never touches the global registry.
 pub struct PConQueryResult<'c, 't, 'tc, T: mysql::prelude::Protocol> {
     pub(crate) result: mysql::QueryResult<'c, 't, 'tc, T>,
+    policies: Arc<ColumnPolicies>,
 }
 impl<'c, 't, 'tc, T: mysql::prelude::Protocol> PConQueryResult<'c, 't, 'tc, T> {
+    pub(crate) fn new(result: mysql::QueryResult<'c, 't, 'tc, T>) -> Self {
+        let policies = ColumnPolicies::resolve(result.columns().as_ref());
+        PConQueryResult { result, policies }
+    }
     pub fn affected_rows(&self) -> u64 {
         self.result.affected_rows()
     }
@@ -24,7 +34,7 @@ impl<'c, 't, 'tc, T: mysql::prelude::Protocol> Iterator for PConQueryResult<'c, 
         match self.result.next() {
             None => None,
             Some(row) => match row {
-                Ok(row) => Some(Ok(PConRow::new(row))),
+                Ok(row) => Some(Ok(PConRow::new(row, Arc::clone(&self.policies)))),
                 Err(e) => Some(Err(e)),
             },
         }

--- a/sesame/mysql/src/row.rs
+++ b/sesame/mysql/src/row.rs
@@ -1,22 +1,27 @@
+use std::sync::Arc;
+
 use sesame::pcon::PCon;
 use sesame::policy::AnyPolicy;
 
-use crate::policy::get_schema_policies;
+use crate::policy::ColumnPolicies;
 use crate::{PConFromValue, PConValue};
 
 // mysql imports.
 pub use mysql::prelude::ColumnIndex as PConColumnIndex;
 
-// A result row.
+// A result row. Carries the per-column policy factories its query
+// resolved once, so attaching policies to cells needs no registry
+// lookup here.
 #[derive(Clone)]
 pub struct PConRow {
     row: mysql::Row,
     raw: Vec<mysql::Value>,
+    policies: Arc<ColumnPolicies>,
 }
 impl PConRow {
-    pub(super) fn new(row: mysql::Row) -> Self {
+    pub(super) fn new(row: mysql::Row, policies: Arc<ColumnPolicies>) -> Self {
         let raw = row.clone().unwrap();
-        PConRow { row, raw }
+        PConRow { row, raw, policies }
     }
 
     pub fn get<T: PConFromValue, I: PConColumnIndex>(
@@ -25,9 +30,8 @@ impl PConRow {
     ) -> Option<PCon<T, AnyPolicy>> {
         let columns = self.row.columns_ref();
         let idx = index.idx(columns)?;
-        let table = columns[idx].table_str().into_owned();
         let val = self.row.get(index)?;
-        Some(PCon::new(val, get_schema_policies(table, idx, &self.raw)))
+        Some(PCon::new(val, self.policies.for_cell(idx, &self.raw)))
     }
 
     pub fn take<T: PConFromValue, I: PConColumnIndex>(
@@ -36,20 +40,15 @@ impl PConRow {
     ) -> Option<PCon<T, AnyPolicy>> {
         let columns = self.row.columns_ref();
         let idx = index.idx(columns)?;
-        let table = columns[idx].table_str().into_owned();
         let val = self.row.take(index)?;
-        Some(PCon::new(val, get_schema_policies(table, idx, &self.raw)))
+        Some(PCon::new(val, self.policies.for_cell(idx, &self.raw)))
     }
 
     pub fn unwrap(self) -> Vec<PConValue> {
         self.raw
             .iter()
             .enumerate()
-            .map(|(i, v)| {
-                let columns = self.row.columns_ref();
-                let table = columns[i].table_str().into_owned();
-                PCon::new(v.clone(), get_schema_policies(table, i, &self.raw))
-            })
+            .map(|(i, v)| PCon::new(v.clone(), self.policies.for_cell(i, &self.raw)))
             .collect()
     }
 }


### PR DESCRIPTION
Before this change, sesame_mysql looked up schema policies once per cell. Every call to PConRow::get, take, or unwrap ran get_schema_policies for the cell it touched. Each of those calls allocated a fresh String for the table name, took the SCHEMA_POLICIES read lock, and did a hash map lookup. A SELECT that returns 200 rows of 7 columns paid for 1400 allocations, 1400 lock acquisitions, and 1400 lookups. The real policy work in that query is just one from_row call per row. I profiled a service under saturating load and this bookkeeping showed up as several hundred samples in a ten second CPU capture.

The lookups are redundant because the answer never changes within a query. Every row of a result set has the same columns, so the factory list per column is fixed. The registry itself is also fixed by the time any query runs: the #[schema_policy] macro registers factories from ctor functions before main, and nothing else is supposed to call add_schema_policy. So I moved the lookup to query construction. PConQueryResult::new now resolves the factory list for each of its columns once, taking the lock once and doing one lookup per column. Every row shares that snapshot through an Arc, and per-cell attachment just indexes into it. To make the snapshot cheap I changed the registry to store each factory behind an Arc, so resolving clones a pointer instead of copying anything.

The policies that reach each cell are unchanged. A cell still gets the same fold of the same factories applied to the same raw row, and NoPolicy where no factory is registered. get_schema_policies keeps its public signature and behavior. I verified this against the Tahini test suites, including the cross-user denial and persistence gating integration tests, and everything passes unchanged.