### PR TITLE
feat(rocket): launch SesameRocket on a caller-supplied Listener

### DIFF
--- a/sesame/rocket/src/rocket/rocket.rs
+++ b/sesame/rocket/src/rocket/rocket.rs
@@ -21,6 +21,17 @@ impl SesameRocket<rocket::Build> {
         }
     }
     // Finish building by launching and awaiting result.
+    /// Launch on a caller-supplied `Listener` instead of Rocket's
+    /// built-in TCP and rustls pair, for applications that bring their
+    /// own TLS stack. Forwards to `Rocket::launch_with_listener`.
+    pub async fn launch_with_listener<L>(self, listener: L) -> Result<(), rocket::Error>
+    where
+        L: rocket::http::private::Listener + Send,
+        <L as rocket::http::private::Listener>::Connection: Send + Unpin + 'static,
+    {
+        self.frontend.launch_with_listener(listener).await
+    }
+
     pub async fn launch(self) -> Result<(), rocket::Error> {
         self.frontend.launch().await
     }


### PR DESCRIPTION
`SesameRocket::launch` can only reach the transports Rocket ships with, TCP and rustls, so a Sesame application that brings its own TLS stack cannot serve through it at all. I hit this driving fizz-rs TLS in the Tahini benchmarks. My workaround was to vendor a patched copy of sesame_rocket carrying this one method, which cost me real time this week: because the copy does not receive upstream changes, your rendering optimization did not reach my application until I re-vendored the whole src tree by hand and reapplied the patch. A build script patch is not an option either, since Cargo reads a path dependency's source before any other crate's build script runs. This adds `launch_with_listener`, an eleven-line forward to the method of the same name on the underlying Rocket. Note that it depends on KinanBab/Rocket#1, which adds that method to your Rocket fork, and it will not compile before that lands. With both merged I can delete the vendored copy and depend on sesame_rocket directly, so your future rendering work reaches me for free.